### PR TITLE
Add unit tests for EC2 resource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rubocop', '~> 0.44.0'
 gem 'highline', '~> 1.6.0'
 gem 'aws-sdk'
 gem 'nokogiri'
+gem 'minitest', '5.10.1'
 
 group :tools do
   gem 'github_changelog_generator', '~> 1.12.0'

--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ end
 
 ## Tests
 
+### Unit tests
+
+To execute the unit tests, run:
+
+```
+bundle exec rake test
+```
+
+### Integration tests
+
 To run the integration tests, please make sure all required environment variables like `AWS_ACCESS_KEY_ID`
 , `AWS_SECRET_ACCESS_KEY` and `AWS_DEFAULT_REGION` are set properly. (`AWS_DEFAULT_REGION` **must** be set to **us-east-1** when running the integration tests.) We use terraform to create the AWS setup and InSpec to verify the all aspects. Integration tests can be executed via:
 

--- a/Rakefile
+++ b/Rakefile
@@ -10,12 +10,19 @@ task :rubocop do
   RuboCop::RakeTask.new
 end
 
+# Minitest
+Rake::TestTask.new do |t|
+  t.libs << 'libraries'
+  t.libs << 'test/unit'
+  t.pattern = "test/unit/**/*_test.rb"
+end
+
 # lint the project
 desc 'Run robocop linter'
 task lint: [:rubocop]
 
 # run tests
-task default: [:lint]
+task default: [:lint, :test]
 
 namespace :test do
   # run inspec check to verify that the profile is properly configured

--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -16,10 +16,9 @@ class Ec2 < Inspec.resource(1)
     end
   "
 
-  def initialize(opts)
+  def initialize(opts, conn = AWSConnection.new)
     @opts = opts
     @opts.is_a?(Hash) ? @display_name = @opts[:name] : @display_name = opts
-    conn = AWSConnection.new
     @ec2_client = conn.ec2_client
     @ec2_resource = conn.ec2_resource
   end

--- a/test/unit/helper.rb
+++ b/test/unit/helper.rb
@@ -1,0 +1,5 @@
+require 'minitest/autorun'
+require 'minitest/unit'
+require 'minitest/pride'
+
+require 'inspec/resource'

--- a/test/unit/resources/ec2_test.rb
+++ b/test/unit/resources/ec2_test.rb
@@ -14,14 +14,11 @@ class TestEc2 < Minitest::Test
     @mockConn.expect :ec2_resource, @mockResource
   end
 
-  def test_that_id_returns_directly_provided_id
-    @cut = Ec2.new(Id, @mockConn)
-     
-    assert_equal @cut.id, Id
+  def test_that_id_returns_id_directly_when_constructed_with_an_id
+    assert_equal Id, Ec2.new(Id, @mockConn).id
   end
 
-  def test_that_id_returns_id_for_provided_name
-    @cut = Ec2.new({name: 'cut'}, @mockConn)
+  def test_that_id_returns_fetched_id_when_constructed_with_a_name
     mockInstance = Minitest::Mock.new
 
     mockInstance.expect :nil?, false
@@ -29,6 +26,38 @@ class TestEc2 < Minitest::Test
 
     @mockResource.expect :instances, [mockInstance], [Hash]
      
-    assert_equal @cut.id, Id
+    assert_equal Id, Ec2.new({name: 'cut'}, @mockConn).id
   end
+
+  def test_that_instance_returns_instance_when_instance_exists
+    mockInstance = Object.new
+
+    @mockResource.expect :instance, mockInstance, [Id] 
+
+    assert_same mockInstance, Ec2.new(Id, @mockConn).send(:instance)
+  end
+
+  def test_that_instance_returns_nil_when_instance_does_not_exist
+    @mockResource.expect :instance, nil, [Id] 
+
+    assert Ec2.new(Id, @mockConn).send(:instance).nil?
+  end
+
+  def test_that_exists_returns_true_when_instance_exists
+    mockInstance = Object.new
+
+    @mockResource.expect :instance, mockInstance, [Id] 
+
+    assert Ec2.new(Id, @mockConn).exists?
+  end
+
+  # A test similar to this one should pass once issue #13 is fixed`
+  # def test_that_exists_returns_false_when_instance_does_not_exist
+    # @cut = Ec2.new(Id, @mockConn)
+    # mockInstance = Object.new
+
+    # @mockResource.expect :instance, nil, [Id] 
+
+    # assert_false @cut.exists?
+  # end
 end

--- a/test/unit/resources/ec2_test.rb
+++ b/test/unit/resources/ec2_test.rb
@@ -1,0 +1,26 @@
+require 'helper'
+
+require 'ec2'
+
+class TestEc2 < Minitest::Test
+  def setup
+    @conn = Minitest::Mock.new
+    @client = Minitest::Mock.new
+    @resource = Minitest::Mock.new
+
+    @conn.expect :ec2_client, @client
+    @conn.expect :ec2_resource, @resource
+  end
+
+  def test_that_id_returns_directly_provided_id
+    @cut = Ec2.new('i-foo', @conn)
+     
+    assert_equal @cut.id, 'i-foo'
+  end
+
+  # def test_that_id_returns_id_for_provided_name
+    # @cut = Ec2.new({name: 'cut'}, @conn)
+     # 
+    # assert_equal @cut.id, 'i-foo'
+  # end
+end

--- a/test/unit/resources/ec2_test.rb
+++ b/test/unit/resources/ec2_test.rb
@@ -3,24 +3,32 @@ require 'helper'
 require 'ec2'
 
 class TestEc2 < Minitest::Test
-  def setup
-    @conn = Minitest::Mock.new
-    @client = Minitest::Mock.new
-    @resource = Minitest::Mock.new
+  Id = "instance-id"
 
-    @conn.expect :ec2_client, @client
-    @conn.expect :ec2_resource, @resource
+  def setup
+    @mockConn = Minitest::Mock.new
+    @mockClient = Minitest::Mock.new
+    @mockResource = Minitest::Mock.new
+
+    @mockConn.expect :ec2_client, @mockClient
+    @mockConn.expect :ec2_resource, @mockResource
   end
 
   def test_that_id_returns_directly_provided_id
-    @cut = Ec2.new('i-foo', @conn)
+    @cut = Ec2.new(Id, @mockConn)
      
-    assert_equal @cut.id, 'i-foo'
+    assert_equal @cut.id, Id
   end
 
-  # def test_that_id_returns_id_for_provided_name
-    # @cut = Ec2.new({name: 'cut'}, @conn)
-     # 
-    # assert_equal @cut.id, 'i-foo'
-  # end
+  def test_that_id_returns_id_for_provided_name
+    @cut = Ec2.new({name: 'cut'}, @mockConn)
+    mockInstance = Minitest::Mock.new
+
+    mockInstance.expect :nil?, false
+    mockInstance.expect :id, Id
+
+    @mockResource.expect :instances, [mockInstance], [Hash]
+     
+    assert_equal @cut.id, Id
+  end
 end


### PR DESCRIPTION
These add some unit tests to our *ec2* resource, and add the required minitest dependencies.  @vix633 and I hope this will enable the team to write more unit tests as we add more resources.