### PR TITLE
Add rake task to clean up integration test instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,17 @@ To run the integration tests, please make sure all required environment variable
 bundle exec rake test:integration
 ```
 
-Right now, instances are not destroyed automatically. Please use
+Instances are destroyed automatically. To persist instances please use
+
+```
+bundle exec rake test:integration_no_cleanup
+```
+
+To cleanup instances, please use
 
 ```
 bundle exec rake test:cleanup
 ```
-
-to remove the setup created by terraform.
 
 ## Kudos
 

--- a/README.md
+++ b/README.md
@@ -104,17 +104,11 @@ To run the integration tests, please make sure all required environment variable
 bundle exec rake test:integration
 ```
 
-Instances are destroyed automatically. To persist instances please use
+This task sets up test AWS resources, runs the integration tests, and then cleans up the resources.  To perform these tasks independently, please call them individually:
 
-```
-bundle exec rake test:integration_no_cleanup
-```
-
-To cleanup instances, please use
-
-```
-bundle exec rake test:cleanup
-```
+* `bundle exec rake test:setup_integration_tests`
+* `bundle exec rake test:run_integration_tests`
+* `bundle exec rake test:cleanup_integration_tests`
 
 ## Kudos
 

--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,8 @@ task lint: [:rubocop]
 task default: [:lint, :test]
 
 namespace :test do
+  integration_dir = "test/integration"
+
   # run inspec check to verify that the profile is properly configured
   task :check do
     dir = File.join(File.dirname(__FILE__))
@@ -32,23 +34,17 @@ namespace :test do
   end
 
   task :setup_integration_tests do
-    integration_dir = "test/integration"
-
     puts "----> Setup"
     sh("cd #{integration_dir}/build/ && terraform plan")
     sh("cd #{integration_dir}/build/ && terraform apply")
   end
 
   task :run_integration_tests do
-    integration_dir = "test/integration"
-
     puts "----> Run"
     sh("bundle exec inspec exec #{integration_dir}/verify")
   end
 
   task :cleanup_integration_tests do
-    integration_dir = "test/integration"
-
     puts "----> Cleanup"
     sh("cd #{integration_dir}/build/ && terraform destroy -force")
   end
@@ -58,11 +54,5 @@ namespace :test do
     Rake::Task["test:setup_integration_tests"].execute
     Rake::Task["test:run_integration_tests"].execute
     Rake::Task["test:cleanup_integration_tests"].execute
-  end
-
-  task :cleanup do
-    integration_dir = "test/integration"
-    puts "----> Destroy"
-    sh("cd #{integration_dir}/build/ && terraform destroy -force")
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ namespace :test do
     sh("bundle exec inspec check #{dir}")
   end
 
-  task :integration do
+  task :integration_no_cleanup do
     integration_dir = "test/integration"
 
     puts "----> Build"
@@ -40,6 +40,12 @@ namespace :test do
 
     puts "----> Verify"
     sh("bundle exec inspec exec #{integration_dir}/verify")
+  end
+
+  task :integration do
+    Rake::Task["test:cleanup"].execute
+    Rake::Task["test:integration_no_cleanup"].execute
+    Rake::Task["test:cleanup"].execute
   end
 
   task :cleanup do

--- a/Rakefile
+++ b/Rakefile
@@ -31,21 +31,33 @@ namespace :test do
     sh("bundle exec inspec check #{dir}")
   end
 
-  task :integration_no_cleanup do
+  task :setup_integration_tests do
     integration_dir = "test/integration"
 
-    puts "----> Build"
+    puts "----> Setup"
     sh("cd #{integration_dir}/build/ && terraform plan")
     sh("cd #{integration_dir}/build/ && terraform apply")
+  end
 
-    puts "----> Verify"
+  task :run_integration_tests do
+    integration_dir = "test/integration"
+
+    puts "----> Run"
     sh("bundle exec inspec exec #{integration_dir}/verify")
   end
 
+  task :cleanup_integration_tests do
+    integration_dir = "test/integration"
+
+    puts "----> Cleanup"
+    sh("cd #{integration_dir}/build/ && terraform destroy -force")
+  end
+
   task :integration do
-    Rake::Task["test:cleanup"].execute
-    Rake::Task["test:integration_no_cleanup"].execute
-    Rake::Task["test:cleanup"].execute
+    Rake::Task["test:cleanup_integration_tests"].execute
+    Rake::Task["test:setup_integration_tests"].execute
+    Rake::Task["test:run_integration_tests"].execute
+    Rake::Task["test:cleanup_integration_tests"].execute
   end
 
   task :cleanup do


### PR DESCRIPTION
Making the default integration test target cleanup before and after.