### PR TITLE
Add a new access-key resource

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ Encoding:
 HashSyntax:
   Enabled: true
 LineLength:
-  Enabled: false
+  Enabled: true
 EmptyLinesAroundBlockBody:
   Enabled: false
 MethodLength:

--- a/libraries/aws_iam_access_key.rb
+++ b/libraries/aws_iam_access_key.rb
@@ -3,7 +3,7 @@ class AwsIamAccessKey < Inspec.resource(1)
   name 'aws_iam_access_key'
   desc 'Verifies settings for AWS IAM access keys'
   example "
-    describe aws_iam_access_key('access-key id') do
+    describe aws_iam_access_key(username: 'username', id: 'access-key id') do
       its('last_use') { should be > Time.now - 90 * 86400 }
     end
   "

--- a/libraries/aws_iam_access_key.rb
+++ b/libraries/aws_iam_access_key.rb
@@ -1,0 +1,50 @@
+# author: Chris Redekop
+class AwsIamAccessKey < Inspec.resource(1)
+  name 'aws_iam_access_key'
+  desc 'Verifies settings for AWS IAM access keys'
+  example "
+    describe aws_iam_access_key('access-key id') do
+      its('last_use') { should be > Time.now - 90 * 86400 }
+    end
+  "
+  def initialize(opts, conn = AWSConnection.new)
+    @opts = opts
+    @access_key = opts[:access_key]
+    @iam_client = conn.iam_client
+  end
+
+  def id
+    access_key.access_key_id
+  end
+
+  def active?
+    'Active'.eql? access_key.status
+  end
+
+  def create_date
+    access_key.create_date
+  end
+
+  def last_used_date
+    access_key_last_used.last_used_date
+  end
+
+private
+
+  def access_key_last_used
+    @access_key_last_used ||= @iam_client.get_access_key_last_used({ access_key_id: access_key.access_key_id }).access_key_last_used
+  end
+
+  def access_key
+    if !@access_key
+      @iam_client.list_access_keys({ user_name: @opts[:username] }).access_key_metadata.each do |access_key|
+        if access_key.access_key_id.eql? @opts[:id]
+          @access_key = access_key
+          break
+        end
+      end
+    end
+
+    @access_key
+  end
+end

--- a/libraries/aws_iam_access_key.rb
+++ b/libraries/aws_iam_access_key.rb
@@ -31,12 +31,19 @@ class AwsIamAccessKey < Inspec.resource(1)
   private
 
   def access_key_last_used
-    @access_key_last_used ||= @iam_client.get_access_key_last_used({ access_key_id: access_key_metadata.access_key_id }).access_key_last_used
+    @access_key_last_used ||=
+      @iam_client.get_access_key_last_used(
+        {
+          access_key_id: access_key_metadata.access_key_id,
+        },
+      ).access_key_last_used
   end
 
   def access_key_metadata
-    if !(defined? @access_key_metadata) || !@access_key_metadata
-      @iam_client.list_access_keys({ user_name: @opts[:username] }).access_key_metadata.each do |access_key_metadata|
+    unless (defined? @access_key_metadata) && @access_key_metadata
+      @iam_client.list_access_keys({ user_name: @opts[:username] })
+                 .access_key_metadata.each do |access_key_metadata|
+
         if access_key_metadata.access_key_id.eql? @opts[:id]
           @access_key_metadata = access_key_metadata
           break

--- a/libraries/aws_iam_access_key.rb
+++ b/libraries/aws_iam_access_key.rb
@@ -9,20 +9,19 @@ class AwsIamAccessKey < Inspec.resource(1)
   "
   def initialize(opts, conn = AWSConnection.new)
     @opts = opts
-    @access_key = opts[:access_key]
     @iam_client = conn.iam_client
   end
 
   def id
-    access_key.access_key_id
+    access_key_metadata.access_key_id
   end
 
   def active?
-    'Active'.eql? access_key.status
+    'Active'.eql? access_key_metadata.status
   end
 
   def create_date
-    access_key.create_date
+    access_key_metadata.create_date
   end
 
   def last_used_date
@@ -32,19 +31,19 @@ class AwsIamAccessKey < Inspec.resource(1)
   private
 
   def access_key_last_used
-    @access_key_last_used ||= @iam_client.get_access_key_last_used({ access_key_id: access_key.access_key_id }).access_key_last_used
+    @access_key_last_used ||= @iam_client.get_access_key_last_used({ access_key_id: access_key_metadata.access_key_id }).access_key_last_used
   end
 
-  def access_key
-    if !@access_key
-      @iam_client.list_access_keys({ user_name: @opts[:username] }).access_key_metadata.each do |access_key|
-        if access_key.access_key_id.eql? @opts[:id]
-          @access_key = access_key
+  def access_key_metadata
+    if !(defined? @access_key_metadata) || !@access_key_metadata
+      @iam_client.list_access_keys({ user_name: @opts[:username] }).access_key_metadata.each do |access_key_metadata|
+        if access_key_metadata.access_key_id.eql? @opts[:id]
+          @access_key_metadata = access_key_metadata
           break
         end
       end
     end
 
-    @access_key
+    @access_key_metadata
   end
 end

--- a/libraries/aws_iam_access_key.rb
+++ b/libraries/aws_iam_access_key.rb
@@ -29,7 +29,7 @@ class AwsIamAccessKey < Inspec.resource(1)
     access_key_last_used.last_used_date
   end
 
-private
+  private
 
   def access_key_last_used
     @access_key_last_used ||= @iam_client.get_access_key_last_used({ access_key_id: access_key.access_key_id }).access_key_last_used

--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -74,7 +74,9 @@ class Ec2 < Inspec.resource(1)
   end
 
   def security_groups
-    @security_groups ||= instance.security_groups.map { |sg| { id: sg.group_id, name: sg.group_name } }
+    @security_groups ||= instance.security_groups.map { |sg|
+      { id: sg.group_id, name: sg.group_name }
+    }
   end
 
   def tags

--- a/test/unit/resources/aws_iam_access_key_test.rb
+++ b/test/unit/resources/aws_iam_access_key_test.rb
@@ -25,7 +25,6 @@ class AwsIamAccessKeyTest < Minitest::Test
     assert_equal AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).id, Id
   end
 
-=begin
   def test_that_active_returns_true_when_access_key_status_is_active
     @mockAccessKey.expect :status, 'Active'
 
@@ -52,5 +51,4 @@ class AwsIamAccessKeyTest < Minitest::Test
 
     assert_equal AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).last_used_date, Date
   end
-=end
 end

--- a/test/unit/resources/aws_iam_access_key_test.rb
+++ b/test/unit/resources/aws_iam_access_key_test.rb
@@ -1,0 +1,64 @@
+# author: Chris Redekop
+require 'aws-sdk'
+require 'helper'
+
+require 'aws_iam_access_key'
+
+class AwsIamAccessKeyTest < Minitest::Test
+  Username = 'test'
+  Id = 'id'
+  Date = 'date'
+
+  def setup
+    @mockConn = Minitest::Mock.new
+    @mockClient = Minitest::Mock.new
+    @mockAccessKey = Minitest::Mock.new
+
+    @mockConn.expect :iam_client, @mockClient
+  end
+
+  def test_that_id_returns_access_key_id_always
+    mock_access_key_lookup
+    @mockAccessKey.expect :access_key_id, Id
+
+    assert_equal AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).id, Id
+  end
+
+  def test_that_active_returns_true_when_access_key_status_is_active
+    mock_access_key_lookup
+    @mockAccessKey.expect :status, 'Active'
+
+    assert AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).active?
+  end
+
+  def test_that_active_returns_false_when_access_key_status_is_not_active
+    mock_access_key_lookup
+    @mockAccessKey.expect :status, 'Foo'
+
+    assert !AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).active?
+  end
+
+  def test_that_create_date_returns_access_key_last_used_date_always
+    mock_access_key_lookup
+    @mockAccessKey.expect :create_date, Date
+
+    assert_equal AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).create_date, Date
+  end
+
+  def test_that_create_returns_access_key_create_date_always
+    mock_access_key_lookup
+    @mockAccessKey.expect :access_key_id, Id
+    mockAccessKeyLastUsed = Minitest::Mock.new
+    mockAccessKeyLastUsed.expect :last_used_date, Date
+    @mockClient.expect :get_access_key_last_used, OpenStruct.new({'access_key_last_used' => mockAccessKeyLastUsed}), [{access_key_id: Id}]
+
+    assert_equal AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).last_used_date, Date
+  end
+
+private
+
+  def mock_access_key_lookup
+    @mockClient.expect :list_access_keys, OpenStruct.new({'access_key_metadata' => [@mockAccessKey]}), [{user_name: Username}]
+    @mockAccessKey.expect :access_key_id, Id
+  end
+end

--- a/test/unit/resources/aws_iam_access_key_test.rb
+++ b/test/unit/resources/aws_iam_access_key_test.rb
@@ -15,38 +15,36 @@ class AwsIamAccessKeyTest < Minitest::Test
     @mockAccessKey = Minitest::Mock.new
 
     @mockConn.expect :iam_client, @mockClient
+    @mockClient.expect :list_access_keys, OpenStruct.new({'access_key_metadata' => [@mockAccessKey]}), [{user_name: Username}]
+    @mockAccessKey.expect :access_key_id, Id
   end
 
   def test_that_id_returns_access_key_id_always
-    mock_access_key_lookup
     @mockAccessKey.expect :access_key_id, Id
 
     assert_equal AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).id, Id
   end
 
+=begin
   def test_that_active_returns_true_when_access_key_status_is_active
-    mock_access_key_lookup
     @mockAccessKey.expect :status, 'Active'
 
     assert AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).active?
   end
 
   def test_that_active_returns_false_when_access_key_status_is_not_active
-    mock_access_key_lookup
     @mockAccessKey.expect :status, 'Foo'
 
     assert !AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).active?
   end
 
   def test_that_create_date_returns_access_key_last_used_date_always
-    mock_access_key_lookup
     @mockAccessKey.expect :create_date, Date
 
     assert_equal AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).create_date, Date
   end
 
   def test_that_create_returns_access_key_create_date_always
-    mock_access_key_lookup
     @mockAccessKey.expect :access_key_id, Id
     mockAccessKeyLastUsed = Minitest::Mock.new
     mockAccessKeyLastUsed.expect :last_used_date, Date
@@ -54,11 +52,5 @@ class AwsIamAccessKeyTest < Minitest::Test
 
     assert_equal AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).last_used_date, Date
   end
-
-private
-
-  def mock_access_key_lookup
-    @mockClient.expect :list_access_keys, OpenStruct.new({'access_key_metadata' => [@mockAccessKey]}), [{user_name: Username}]
-    @mockAccessKey.expect :access_key_id, Id
-  end
+=end
 end


### PR DESCRIPTION
This gives us a new standalone access-key resource.  Because we need both user ID and an (AWS-generated) access-key ID to integration test, we currently don't have an integration test.  Options:

1. Wait until our user resource returns keys (see #26) and access our keys in our integration tests through a user.
2. Implement #27 .

I was able to manually test with
```ruby
describe aws_iam_access_key(username: 'credekop', id: 'AKIAJVIW6M5AHBGAEUNQ') do
  it { should be_active }
  its('last_used_date') { should be > Time.now + 90 * 86400 }
end
```