### PR TITLE
User provider refactor

### DIFF
--- a/libraries/aws_iam_user.rb
+++ b/libraries/aws_iam_user.rb
@@ -10,19 +10,16 @@ class AwsIamUser < Inspec.resource(1)
       its('has_console_password?') { should be true }
     end
   "
-  def initialize(name, conn = AWSConnection.new)
+  def initialize(name, aws_user_provider = AwsIam::UserProvider.new)
     @name = name
-    @iam_resource = conn.iam_resource
-    @user = @iam_resource.user(@name)
+    @user = aws_user_provider.get_user(name)
   end
 
   def has_mfa_enabled?
-    !@user.mfa_devices.first.nil?
+    @user[:has_mfa_enabled?]
   end
 
   def has_console_password?
-    return !@user.login_profile.create_date.nil?
-  rescue Aws::IAM::Errors::NoSuchEntity
-    return false
+    @user[:has_console_password?]
   end
 end

--- a/libraries/aws_iam_user_provider.rb
+++ b/libraries/aws_iam_user_provider.rb
@@ -1,0 +1,34 @@
+# author: Alex Bedley
+# author: Steffanie Freeman
+
+module AwsIam
+  class UserProvider
+    def initialize(conn = AWSConnection.new)
+      @iam_resource = conn.iam_resource
+    end
+
+    def get_user(name)
+      aws_user = @iam_resource.user(name)
+      self.class.convert(aws_user)
+    end
+
+    class << self
+      def has_mfa_enabled?(aws_user)
+        !aws_user.mfa_devices.first.nil?
+      end
+
+      def has_console_password?(aws_user)
+        return !aws_user.login_profile.create_date.nil?
+      rescue Aws::IAM::Errors::NoSuchEntity
+        return false
+      end
+
+      def convert(aws_user)
+        {
+          has_mfa_enabled?: has_mfa_enabled?(aws_user),
+          has_console_password?: has_console_password?(aws_user),
+        }
+      end
+    end
+  end
+end

--- a/test/unit/resources/aws_iam_user_provider_test.rb
+++ b/test/unit/resources/aws_iam_user_provider_test.rb
@@ -1,0 +1,82 @@
+# author: Simon Varlow
+# author: Jeffrey Lyons
+# author: Steffanie Freeman
+# author: Alex Bedley
+require 'aws-sdk'
+require 'helper'
+
+require 'aws_iam_user_provider'
+
+class AwsIamUserProviderTest < Minitest::Test
+  Username = "test"
+
+  def setup
+    @mock_iam_resource = Minitest::Mock.new
+    @mock_aws_connection = Minitest::Mock.new
+    @mock_aws_connection.expect :iam_resource, @mock_iam_resource
+    @user_provider = AwsIam::UserProvider.new(@mock_aws_connection)
+  end
+
+  def test_get_user
+    @mock_iam_resource.expect :user, create_mock_user, [Username]
+    assert !@user_provider.get_user(Username).nil?
+  end
+
+  def test_has_mfa_enabled_returns_true
+    @mock_iam_resource.expect :user, create_mock_user(has_mfa_enabled: true), [Username]
+    assert @user_provider.get_user(Username)[:has_mfa_enabled?]
+  end
+
+  def test_has_mfa_enabled_returns_false
+    @mock_iam_resource.expect :user, create_mock_user(has_mfa_enabled: false), [Username]
+    assert !@user_provider.get_user(Username)[:has_mfa_enabled?]
+  end
+  
+  def test_has_console_password_returns_true
+    @mock_iam_resource.expect :user, create_mock_user(has_console_password: true), [Username]
+    assert @user_provider.get_user(Username)[:has_console_password?]
+  end
+
+  def test_has_console_password_returns_false
+    @mock_iam_resource.expect :user, create_mock_user(has_console_password: false), [Username]
+    assert !@user_provider.get_user(Username)[:has_console_password?]
+  end
+  
+  def test_has_console_password_returns_false_when_nosuchentity
+    @mock_iam_resource.expect :user, create_mock_user_throw(Aws::IAM::Errors::NoSuchEntity.new(nil, nil)), [Username]
+    
+    assert !@user_provider.get_user(Username)[:has_console_password?]
+  end
+  
+  def test_has_console_password_throws
+    @mock_iam_resource.expect :user, create_mock_user_throw(ArgumentError), [Username]
+    
+    assert_raises ArgumentError do
+      @user_provider.get_user(Username)
+    end
+  end
+
+  private
+
+  def create_mock_user(has_console_password: true, has_mfa_enabled: true)
+    mock_user = Minitest::Mock.new
+    mock_login_profile = Minitest::Mock.new
+    
+    mock_user.expect :mfa_devices, has_mfa_enabled ? ['device'] : []
+    
+    mock_login_profile.expect :create_date, has_console_password ? 'date' : nil
+    mock_user.expect :login_profile, mock_login_profile
+  end
+  
+  def create_mock_user_throw(exception)
+    mock_user = Minitest::Mock.new
+    mock_login_profile = Minitest::Mock.new
+    
+    mock_user.expect :mfa_devices, []
+    
+    mock_login_profile.expect :create_date, nil do |args|
+      raise exception
+    end
+    mock_user.expect :login_profile, mock_login_profile
+  end
+end

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -8,53 +8,26 @@ class AwsIamUserTest < Minitest::Test
 Username = "test" 
   
   def setup
-    @mockConn = Minitest::Mock.new
-    @mockUser = Minitest::Mock.new
-    @mockResource = Minitest::Mock.new
-    @mockProfile = Minitest::Mock.new
-
-    @mockConn.expect :iam_resource, @mockResource
-    @mockResource.expect :user, @mockUser, [String]
+    @mock_user_provider = Minitest::Mock.new
   end
 
   def test_that_MFA_enable_returns_true_if_MFA_Enabled
-    @mockUser.expect :mfa_devices, ["test"]
-    assert AwsIamUser.new(Username, @mockConn).has_mfa_enabled?
+    @mock_user_provider.expect :get_user, {has_mfa_enabled?: true}, [Username]
+    assert AwsIamUser.new(Username, @mock_user_provider).has_mfa_enabled?
   end
 
   def test_that_MFA_enable_returns_false_if_MFA_is_not_Enabled
-    @mockUser.expect :mfa_devices, []
-    assert !AwsIamUser.new(Username, @mockConn).has_mfa_enabled?
+    @mock_user_provider.expect :get_user, {has_mfa_enabled?: false}, [Username]
+    assert !AwsIamUser.new(Username, @mock_user_provider).has_mfa_enabled?
   end
 
   def test_that_console_Password_returns_true_if_console_Password_has_been_set
-    @mockUser.expect :login_profile, @mockProfile
-    @mockProfile.expect :create_date, "test"
-    assert AwsIamUser.new(Username, @mockConn).has_console_password?
+    @mock_user_provider.expect :get_user, {has_console_password?: true}, [Username]
+    assert AwsIamUser.new(Username, @mock_user_provider).has_console_password?
   end
 
   def test_that_console_Password_returns_false_if_console_Password_has_not_been_set
-    @mockUser.expect :login_profile, @mockProfile
-    @mockProfile.expect :create_date, nil
-    assert !AwsIamUser.new(Username, @mockConn).has_console_password?
-  end
-
-  def test_that_console_Password_returns_false_if_console_Password_throws_no_such_entity
-    @mockUser.expect :login_profile, @mockProfile
-    @mockProfile.expect :create_date, nil do |args|
-      raise Aws::IAM::Errors::NoSuchEntity.new nil, nil
-    end
-    assert !AwsIamUser.new(Username, @mockConn).has_console_password?
-  end
-
-  def test_that_console_Password_throws_if_console_Password_throws_not_no_such_entity
-    @mockUser.expect :login_profile, @mockProfile
-    @mockProfile.expect :create_date, nil do |args|
-      raise ArgumentError
-    end
-
-    assert_raises ArgumentError do
-      AwsIamUser.new(Username, @mockConn).has_console_password?
-    end
+    @mock_user_provider.expect :get_user, {has_console_password?: false}, [Username]
+    assert !AwsIamUser.new(Username, @mock_user_provider).has_console_password?
   end
 end


### PR DESCRIPTION
Refactor `aws_iam_user` to use a `user_provider` which is responsible for communicating with AWS and massaging the user data into a hash.

The purpose of this refactor is to prepare for `aws_iam_users` which will use the same `user_provider` under the hood. Additionally, this simplifies our inspec resources by reducing their responsibilities.

TODO

- [x] squash + rebase after review