### PR TITLE
Defensive programming for aws_iam_access_key

### DIFF
--- a/libraries/aws_iam_access_key.rb
+++ b/libraries/aws_iam_access_key.rb
@@ -18,9 +18,7 @@ class AwsIamAccessKey < Inspec.resource(1)
 
   def exists?
     !access_key.nil?
-  rescue AccessKeyNotFoundError
-    false
-  rescue Aws::IAM::Errors::NoSuchEntity
+  rescue AccessKeyNotFoundError, Aws::IAM::Errors::NoSuchEntity
     false
   end
 

--- a/libraries/aws_iam_access_key.rb
+++ b/libraries/aws_iam_access_key.rb
@@ -4,53 +4,100 @@ class AwsIamAccessKey < Inspec.resource(1)
   desc 'Verifies settings for AWS IAM access keys'
   example "
     describe aws_iam_access_key(username: 'username', id: 'access-key id') do
-      its('last_use') { should be > Time.now - 90 * 86400 }
+      it { should exist }
+      it { should_not be_active }
+      its('create_date') { should be > Time.now - 365 * 86400 }
+      its('last_used_date') { should be > Time.now - 90 * 86400 }
     end
   "
-  def initialize(opts, conn = AWSConnection.new)
+
+  def initialize(opts, decorator = IamClientDecorator.new)
     @opts = opts
-    @iam_client = conn.iam_client
+    @decorator = decorator
+  end
+
+  def exists?
+    !access_key.nil?
+  rescue AccessKeyNotFoundError
+    false
+  rescue Aws::IAM::Errors::NoSuchEntity
+    false
   end
 
   def id
-    access_key_metadata.access_key_id
+    access_key.access_key_id
   end
 
   def active?
-    'Active'.eql? access_key_metadata.status
+    'Active'.eql? access_key.status
   end
 
   def create_date
-    access_key_metadata.create_date
+    access_key.create_date
   end
 
   def last_used_date
     access_key_last_used.last_used_date
   end
 
-  private
-
-  def access_key_last_used
-    @access_key_last_used ||=
-      @iam_client.get_access_key_last_used(
-        {
-          access_key_id: access_key_metadata.access_key_id,
-        },
-      ).access_key_last_used
+  def to_s
+    "IAM Access-Key #{@opts[:id]}"
   end
 
-  def access_key_metadata
-    unless (defined? @access_key_metadata) && @access_key_metadata
-      @iam_client.list_access_keys({ user_name: @opts[:username] })
-                 .access_key_metadata.each do |access_key_metadata|
+  class AccessKeyNotFoundError < StandardError
+  end
 
-        if access_key_metadata.access_key_id.eql? @opts[:id]
-          @access_key_metadata = access_key_metadata
-          break
+  class IamClientDecorator
+    def initialize(validator = ArgumentValidator.new,
+                   conn = AWSConnection.new)
+
+      @validator = validator
+      @client = conn.iam_client
+    end
+
+    def get_access_key(username, id)
+      @validator.validate_username(username)
+      @validator.validate_id(id)
+
+      access_key =
+        @client.list_access_keys({ user_name: username })
+               .access_key_metadata.select { |x| x.access_key_id.eql? id }.first
+
+      if access_key.nil?
+        raise AccessKeyNotFoundError, 'access key not found '.concat(
+          "[username = \"#{username}\", id = \"#{id}\"]",
+        )
+      end
+
+      access_key
+    end
+
+    def get_access_key_last_used(id)
+      @validator.validate_id(id)
+
+      @client.get_access_key_last_used({ access_key_id: id })
+             .access_key_last_used
+    end
+
+    class ArgumentValidator
+      [:username, :id].each do |argument|
+        define_method "validate_#{argument}" do |value|
+          return unless value.nil?
+
+          raise ArgumentError,
+                "missing required resource argument \"#{argument}\""
         end
       end
     end
+  end
 
-    @access_key_metadata
+  private
+
+  def access_key
+    @access_key ||= @decorator.get_access_key(@opts[:username], @opts[:id])
+  end
+
+  def access_key_last_used
+    @access_key_last_used ||= @decorator.get_access_key_last_used(@opts[:id])
   end
 end

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -23,3 +23,7 @@ resource "aws_iam_user_login_profile" "u" {
         user = "${aws_iam_user.console_password_enabled_user.name}"
         pgp_key = "${var.login_profile_pgp_key}"
 }
+
+resource "aws_iam_user" "access_key_user" {
+    name = "access_key_user"
+}

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -23,7 +23,3 @@ resource "aws_iam_user_login_profile" "u" {
         user = "${aws_iam_user.console_password_enabled_user.name}"
         pgp_key = "${var.login_profile_pgp_key}"
 }
-
-resource "aws_iam_user" "access_key_user" {
-    name = "access_key_user"
-}

--- a/test/integration/verify/controls/aws_iam_access_key.rb
+++ b/test/integration/verify/controls/aws_iam_access_key.rb
@@ -1,0 +1,3 @@
+describe aws_iam_access_key(username: 'not-a-user', 'id': 'not-an-id') do
+  it { should_not exist }
+end

--- a/test/unit/resources/aws_iam_access_key_test.rb
+++ b/test/unit/resources/aws_iam_access_key_test.rb
@@ -85,14 +85,13 @@ class AwsIamAccessKeyTest < Minitest::Test
     def test_get_access_key_raises_when_no_access_keys_found
       validator = mock_validator
       
-      begin
+      e = assert_raises AwsIamAccessKey::AccessKeyNotFoundError do
         iam_client_decorator(validator).get_access_key(Username, Id)
-	flunk
-      rescue AwsIamAccessKey::AccessKeyNotFoundError => e
-        assert_match(/.*access key not found.*/, e.message)
-        assert_match(/.*#{Username}.*/, e.message)
-        assert_match(/.*#{Id}.*/, e.message)
       end
+
+      assert_match(/.*access key not found.*/, e.message)
+      assert_match(/.*#{Username}.*/, e.message)
+      assert_match(/.*#{Id}.*/, e.message)
 
       validator.verify
     end
@@ -100,15 +99,14 @@ class AwsIamAccessKeyTest < Minitest::Test
     def test_get_access_key_raises_when_matching_access_key_not_found
       validator = mock_validator
       
-      begin
+      e = assert_raises AwsIamAccessKey::AccessKeyNotFoundError do 
         iam_client_decorator(validator, [stub_access_key(id: 'Foo')])
           .get_access_key(Username, Id)
-	flunk
-      rescue AwsIamAccessKey::AccessKeyNotFoundError => e
-        assert_match(/.*access key not found.*/, e.message)
-        assert_match(/.*#{Username}.*/, e.message)
-        assert_match(/.*#{Id}.*/, e.message)
       end
+
+      assert_match(/.*access key not found.*/, e.message)
+      assert_match(/.*#{Username}.*/, e.message)
+      assert_match(/.*#{Id}.*/, e.message)
 
       validator.verify
     end

--- a/test/unit/resources/aws_iam_access_key_test.rb
+++ b/test/unit/resources/aws_iam_access_key_test.rb
@@ -1,54 +1,236 @@
 # author: Chris Redekop
+
 require 'aws-sdk'
 require 'helper'
 
 require 'aws_iam_access_key'
 
 class AwsIamAccessKeyTest < Minitest::Test
-  Username = 'test'
+  Username = 'test' 
   Id = 'id'
   Date = 'date'
 
-  def setup
-    @mockConn = Minitest::Mock.new
-    @mockClient = Minitest::Mock.new
-    @mockAccessKey = Minitest::Mock.new
+  module AccessKeyFactory
+    def aws_iam_access_key(decorator = mock_decorator(stub_access_key))
+      AwsIamAccessKey.new({ username: Username, id: Id }, decorator)
+    end
 
-    @mockConn.expect :iam_client, @mockClient
-    @mockClient.expect :list_access_keys, OpenStruct.new({'access_key_metadata' => [@mockAccessKey]}), [{user_name: Username}]
-    @mockAccessKey.expect :access_key_id, Id
+    def stub_access_key(
+      _nil: false,
+      id: Id,
+      status: 'Active',
+      create_date: Date
+    )
+      OpenStruct.new({
+        :nil? => _nil,
+        :access_key_id => id,
+        :status => status,
+        :create_date => create_date
+      })
+    end
   end
 
-  def test_that_id_returns_access_key_id_always
-    @mockAccessKey.expect :access_key_id, Id
+  include AccessKeyFactory
 
-    assert_equal AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).id, Id
+  def test_exists_returns_true_when_access_key_exists
+    assert aws_iam_access_key.exists?
   end
 
-  def test_that_active_returns_true_when_access_key_status_is_active
-    @mockAccessKey.expect :status, 'Active'
+  def test_exists_returns_false_when_sdk_raises
+    mock_decorator = mock_decorator_raise(
+      Aws::IAM::Errors::NoSuchEntity.new(nil, nil))
 
-    assert AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).active?
+    refute aws_iam_access_key(mock_decorator).exists?
+
+    mock_decorator.verify
   end
 
-  def test_that_active_returns_false_when_access_key_status_is_not_active
-    @mockAccessKey.expect :status, 'Foo'
+  def test_exists_returns_false_when_access_key_does_not_exist
+    mock_decorator = mock_decorator_raise(
+      AwsIamAccessKey::AccessKeyNotFoundError.new)
 
-    assert !AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).active?
+    refute aws_iam_access_key(mock_decorator).exists?
+
+    mock_decorator.verify
   end
 
-  def test_that_create_date_returns_access_key_last_used_date_always
-    @mockAccessKey.expect :create_date, Date
-
-    assert_equal AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).create_date, Date
+  def test_id_returns_id_when_access_key_exists
+    assert_equal Id, aws_iam_access_key.id
   end
 
-  def test_that_create_returns_access_key_create_date_always
-    @mockAccessKey.expect :access_key_id, Id
-    mockAccessKeyLastUsed = Minitest::Mock.new
-    mockAccessKeyLastUsed.expect :last_used_date, Date
-    @mockClient.expect :get_access_key_last_used, OpenStruct.new({'access_key_last_used' => mockAccessKeyLastUsed}), [{access_key_id: Id}]
+  def test_active_returns_true_when_access_key_is_active
+    assert aws_iam_access_key.active?
+  end
 
-    assert_equal AwsIamAccessKey.new({username: Username, id: Id}, @mockConn).last_used_date, Date
+  def test_active_returns_false_when_access_key_is_not_active
+    refute aws_iam_access_key(mock_decorator(stub_access_key(status: 'Foo')))
+      .active?
+  end
+
+  def test_create_date_returns_create_date_always
+    assert_equal Date, aws_iam_access_key.create_date
+  end
+
+  def test_last_used_date_returns_last_used_date_always
+    assert_equal(
+      Date,
+      aws_iam_access_key(mock_decorator(nil,
+        OpenStruct.new({ :last_used_date => Date }))).last_used_date
+    )
+  end
+
+  class IamClientDecoratorTest < Minitest::Test
+    include AccessKeyFactory
+
+    def test_get_access_key_raises_when_no_access_keys_found
+      validator = mock_validator
+      
+      begin
+        iam_client_decorator(validator).get_access_key(Username, Id)
+	flunk
+      rescue AwsIamAccessKey::AccessKeyNotFoundError => e
+        assert_match(/.*access key not found.*/, e.message)
+        assert_match(/.*#{Username}.*/, e.message)
+        assert_match(/.*#{Id}.*/, e.message)
+      end
+
+      validator.verify
+    end
+
+    def test_get_access_key_raises_when_matching_access_key_not_found
+      validator = mock_validator
+      
+      begin
+        iam_client_decorator(validator, [stub_access_key(id: 'Foo')])
+          .get_access_key(Username, Id)
+	flunk
+      rescue AwsIamAccessKey::AccessKeyNotFoundError => e
+        assert_match(/.*access key not found.*/, e.message)
+        assert_match(/.*#{Username}.*/, e.message)
+        assert_match(/.*#{Id}.*/, e.message)
+      end
+
+      validator.verify
+    end
+
+    def test_get_access_key_returns_access_key_when_access_key_found
+      access_key = stub_access_key
+      validator = mock_validator
+
+      assert_equal(
+        access_key,
+        iam_client_decorator(validator, [access_key]).get_access_key(Username, Id)
+      )
+
+      validator.verify
+    end
+
+    def test_get_access_key_last_used_returns_last_used_when_last_used_found
+      access_key_last_used = Object.new
+      validator = mock_validator(false)
+
+      assert_equal(
+        access_key_last_used,
+        iam_client_decorator(validator, nil, access_key_last_used)
+          .get_access_key_last_used(Id)
+      )
+
+      validator.verify
+    end
+
+    class ArgumentValidatorTest < Minitest::Test
+      def test_validate_id_raises_when_id_is_nil
+        argument_validator.validate_id(nil)
+	flunk
+      rescue ArgumentError => e
+	assert_match(/.*missing.*"id".*/, e.message)
+      end
+
+      def test_validate_id_does_nothing_when_id_is_not_nil
+        argument_validator.validate_id(Id)
+      end
+
+      def test_validate_username_raises_when_username_is_nil
+	argument_validator.validate_username(nil)
+	flunk
+      rescue ArgumentError => e
+	assert_match(/.*missing.*"username".*/, e.message)
+      end
+
+      def test_validate_username_does_nothing_when_username_is_not_nil
+        argument_validator.validate_username(Username) 
+      end
+
+      def argument_validator
+	AwsIamAccessKey::IamClientDecorator::ArgumentValidator.new
+      end
+    end
+
+    def mock_validator(validate_username = true)
+      mock_validator = Minitest::Mock.new.expect :validate_id, nil, [Id]
+
+      if validate_username
+        mock_validator.expect :validate_username, nil, [Username]
+      end
+
+      mock_validator
+    end
+
+    def mock_conn(access_keys, access_key_last_used = nil)
+      Minitest::Mock.new.expect(
+        :iam_client,
+        mock_client(access_keys, access_key_last_used)
+      )
+    end
+
+    def mock_client(access_keys, access_key_last_used)
+      mock_iam_client = Minitest::Mock.new
+
+      if access_keys
+        mock_iam_client.expect(
+          :list_access_keys,
+          OpenStruct.new({'access_key_metadata' => access_keys}),
+          [{user_name: Username}]
+        )
+      end
+
+      if access_key_last_used
+        mock_iam_client.expect(
+          :get_access_key_last_used,
+          OpenStruct.new({'access_key_last_used' => access_key_last_used}),
+          [{access_key_id: Id}]
+        )
+      end
+
+      mock_iam_client
+    end
+
+    def iam_client_decorator(validator, access_keys = [], access_key_last_used = nil)
+      AwsIamAccessKey::IamClientDecorator.new(
+        validator, mock_conn(access_keys, access_key_last_used))
+    end
+  end
+
+  def mock_decorator(access_key, access_key_last_used = nil)
+    mock_decorator = Minitest::Mock.new
+
+    if access_key
+      mock_decorator.expect :get_access_key, access_key, [Username, Id]
+    end
+
+    if access_key_last_used
+      mock_decorator.expect :get_access_key_last_used, access_key_last_used, [Id]
+    end
+
+    mock_decorator
+  end
+
+  def mock_decorator_raise(error)
+    Minitest::Mock.new.expect(:get_access_key, nil) do |username, id|
+      assert_equal Username, username
+      assert_equal Id, id  
+
+      raise error
+    end
   end
 end


### PR DESCRIPTION
Here is a proposal for a more robust aws_iam_access_key resource.  It is based on suggestions from Alex and also follow-up chats with Alex and Christoph.

I put it in it's own PR to get your individual feedback.
1. Alex, is this what you were thinking of, in terms of checking and error messages?
1. Alex and Christoph, what do you think of this approach?  I think it's worth it but I could go either way.  It's a bit more work, but it makes for a much better user experience.

If we want to go this route, I'll
1. close the other PR,
1. add unit tests here,
1. rebase and squash.