### PR TITLE
[ISSUE-24] - Use terraform environment to avoid integration tests collisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+.attribute.yml
+.bundle/
+.terraform/
 inspec.lock
 Gemfile.lock
-terraform.tfstate
+terraform.tfstate*
 terraform.tfstate.backup
+

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ bundle exec rake test
 ### Integration tests
 
 To run the integration tests, please make sure all required environment variables like `AWS_ACCESS_KEY_ID`
-, `AWS_SECRET_ACCESS_KEY` and `AWS_DEFAULT_REGION` are set properly. (`AWS_DEFAULT_REGION` **must** be set to **us-east-1** when running the integration tests.) We use terraform to create the AWS setup and InSpec to verify the all aspects. Integration tests can be executed via:
+, `AWS_SECRET_ACCESS_KEY` and `AWS_DEFAULT_REGION` are set properly. (`AWS_DEFAULT_REGION` **must** be set to **us-east-1** when running the integration tests.) We use terraform to create the AWS setup and InSpec to verify the all aspects. If you want to use a specific terraform environment, set environment variable `INSPEC_TERRAFORM_ENV`. Integration tests can be executed via:
 
 ```
 bundle exec rake test:integration
@@ -105,9 +105,11 @@ bundle exec rake test:integration
 
 This task sets up test AWS resources, runs the integration tests, and then cleans up the resources.  To perform these tasks independently, please call them individually:
 
+* `bundle exec rake test:configure_test_environment`
 * `bundle exec rake test:setup_integration_tests`
 * `bundle exec rake test:run_integration_tests`
 * `bundle exec rake test:cleanup_integration_tests`
+* `bundle exec rake test:destroy_test_environment`
 
 ## Kudos
 

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -5,21 +5,37 @@ resource "aws_instance" "example" {
   instance_type = "t2.micro"
 
   tags {
-    Name = "Example"
+    Name = "${terraform.env}.Example"
     X-Project = "inspec"
   }
 }
 
 resource "aws_iam_user" "mfa_not_enabled_user" {
-    name = "mfa_not_enabled_user"
+    name = "${terraform.env}.mfa_not_enabled_user"
 }
 
 resource "aws_iam_user" "console_password_enabled_user" {
-    name = "console_password_enabled_user"
+    name = "${terraform.env}.console_password_enabled_user"
     force_destroy = true
 }
 
 resource "aws_iam_user_login_profile" "u" {
         user = "${aws_iam_user.console_password_enabled_user.name}"
         pgp_key = "${var.login_profile_pgp_key}"
+}
+
+output "mfa_not_enabled_user" {
+  value = "${aws_iam_user.mfa_not_enabled_user.name}"
+}
+
+output "console_password_enabled_user" {
+  value = "${aws_iam_user.console_password_enabled_user.name}"
+}
+
+output "example_ec2_name" {
+  value = "${aws_instance.example.tags.Name}"
+}
+
+output "example_ec2_id" {
+  value = "${aws_instance.example.id}"
 }

--- a/test/integration/verify/controls/aws.rb
+++ b/test/integration/verify/controls/aws.rb
@@ -1,4 +1,20 @@
-describe aws_ec2(name: 'Example') do
+example_ec2_id = attribute(
+  'example_ec2_id',
+  default: 'default.example_ec2_id',
+  description: 'ID of example ec2 instance')
+
+example_ec2_name = attribute(
+  'example_ec2_name',
+  default: 'default.Example',
+  description: 'Name of exapmle ec2 instance')
+
+describe aws_ec2(name: example_ec2_name) do
+  it { should exist }
+  its('image_id') { should eq 'ami-0d729a60' }
+  its('instance_type') { should eq 't2.micro' }
+end
+
+describe aws_ec2(example_ec2_id) do
   it { should exist }
   its('image_id') { should eq 'ami-0d729a60' }
   its('instance_type') { should eq 't2.micro' }

--- a/test/integration/verify/controls/aws_iam_user.rb
+++ b/test/integration/verify/controls/aws_iam_user.rb
@@ -1,8 +1,18 @@
-describe aws_iam_user('mfa_not_enabled_user') do
+mfa_not_enabled_user = attribute(
+  'mfa_not_enabled_user',
+  default: 'default.mfa_not_enabled_user',
+  description: 'Name of IAM user mfa_not_enabled_user')
+
+console_password_enabled_user = attribute(
+  'console_password_enabled_user',
+  default: 'default.console_password_enabled_user',
+  description: 'Name of IAM user console_password_enabled_user')
+
+describe aws_iam_user(mfa_not_enabled_user) do
   its('has_mfa_enabled?') { should be false }
   its('has_console_password?') { should be false }
 end
 
-describe aws_iam_user('console_password_enabled_user') do
+describe aws_iam_user(console_password_enabled_user) do
   its('has_console_password?') { should be true }
 end


### PR DESCRIPTION
## Summary - Addresses https://github.com/chef/inspec-aws/issues/24
* When running integration tests, use Terraform environment based on environment variable `INSPEC_TERRAFORM_ENV` to avoid collisions
  * If `INSPEC_TERRAFORM_ENV` is not set, a random string will be used
  * I chose not to default to `AWS_SECRET_ACCESS_KEY` if in the future we have parallel integration tests running in Travis
* Use Terraform environment as a namespace for AWS artifacts
* Use attribute file so that Inspec is  aware of the Terraform environment used
* Added additional integration test to cover case where we test by EC2 ID

Signed-off-by: Miles Tjandrawidjaja <miles@tjandrawidjaja.com>