### PR TITLE
[ISSUE-36] - Cover Recommendation 1.10

### DIFF
--- a/libraries/aws_iam_password_policy.rb
+++ b/libraries/aws_iam_password_policy.rb
@@ -59,13 +59,13 @@ class AwsIamPasswordPolicy < Inspec.resource(1)
     @policy.max_password_age
   end
 
-  def prevent_password_reuse?
+  def prevents_password_reuse?
     !@policy.password_reuse_prevention.nil?
   end
 
   def number_of_passwords_to_remember
     raise 'this policy does not prevent password reuse' \
-      unless prevent_password_reuse?
+      unless prevents_password_reuse?
     @policy.password_reuse_prevention
   end
 end

--- a/libraries/aws_iam_password_policy.rb
+++ b/libraries/aws_iam_password_policy.rb
@@ -58,4 +58,14 @@ class AwsIamPasswordPolicy < Inspec.resource(1)
     raise 'this policy does not expire passwords' unless expires_passwords?
     @policy.max_password_age
   end
+
+  def prevent_password_reuse?
+    !@policy.password_reuse_prevention.nil?
+  end
+
+  def number_of_passwords_to_remember
+    raise 'this policy does not prevent password reuse' \
+      unless prevent_password_reuse?
+    @policy.password_reuse_prevention
+  end
 end

--- a/test/unit/resources/aws_iam_password_policy_test.rb
+++ b/test/unit/resources/aws_iam_password_policy_test.rb
@@ -37,4 +37,42 @@ class AwsIamPasswordPolicyTest < Minitest::Test
 
     assert_equal e.message, 'this policy does not expire passwords'
   end
+
+  def test_prevent_password_reuse_returns_true_when_not_nil
+    @mockResource.expect :account_password_policy, create_mock_policy(password_reuse_prevention: Object.new)
+
+    assert_equal true, AwsIamPasswordPolicy.new(@mockConn).prevent_password_reuse?
+  end
+
+  def test_prevent_password_reuse_returns_false_when_nil
+    @mockResource.expect :account_password_policy, create_mock_policy(password_reuse_prevention: nil)
+
+    assert_equal false, AwsIamPasswordPolicy.new(@mockConn).prevent_password_reuse?
+  end
+
+  def test_number_of_passwords_to_remember_throws_when_nil
+    @mockResource.expect :account_password_policy, create_mock_policy(password_reuse_prevention: nil)
+
+    e = assert_raises Exception do
+      AwsIamPasswordPolicy.new(@mockConn).number_of_passwords_to_remember
+    end
+
+    assert_equal e.message, 'this policy does not prevent password reuse'
+  end
+
+
+  def test_number_of_passwords_to_remember_returns_configured_value
+    expectedValue = 5
+    @mockResource.expect :account_password_policy, create_mock_policy(password_reuse_prevention: expectedValue)
+
+    assert_equal expectedValue, AwsIamPasswordPolicy.new(@mockConn).number_of_passwords_to_remember
+  end
+
+  private 
+
+  def create_mock_policy(password_reuse_prevention: nil)
+    Class.new {
+      define_method(:password_reuse_prevention) { password_reuse_prevention }
+    }.new
+  end
 end

--- a/test/unit/resources/aws_iam_password_policy_test.rb
+++ b/test/unit/resources/aws_iam_password_policy_test.rb
@@ -37,16 +37,16 @@ class AwsIamPasswordPolicyTest < Minitest::Test
     assert_equal e.message, 'this policy does not expire passwords'
   end
 
-  def test_prevent_password_reuse_returns_true_when_not_nil
+  def test_prevents_password_reuse_returns_true_when_not_nil
     configure_policy_password_reuse_prevention(value: Object.new)
 
-    assert AwsIamPasswordPolicy.new(@mockConn).prevent_password_reuse?
+    assert AwsIamPasswordPolicy.new(@mockConn).prevents_password_reuse?
   end
 
-  def test_prevent_password_reuse_returns_false_when_nil
+  def test_prevents_password_reuse_returns_false_when_nil
     configure_policy_password_reuse_prevention(value: nil)
 
-    refute AwsIamPasswordPolicy.new(@mockConn).prevent_password_reuse?
+    refute AwsIamPasswordPolicy.new(@mockConn).prevents_password_reuse?
   end
 
   def test_number_of_passwords_to_remember_throws_when_nil


### PR DESCRIPTION
## Summary - Addresses https://github.com/chef/inspec-aws/issues/36
* Covers recommendation 1.10
* I do not know if we should cover this in an integration test, since it doesn't seem Terraform has a revert strategy. **Looking for advice**.

Sample Tests
```
describe aws_iam_password_policy do
  its('prevent_password_reuse?') { should be true }
end


describe aws_iam_password_policy do
  its('number_of_passwords_to_remember') { should eq 1 }
end
```

Sample Failure Output (Manually Tested)
```
aws_iam_password_policy prevent_password_reuse?
   ∅  should equal true
     
   expected true
       got false
     
aws_iam_password_policy number_of_passwords_to_remember
   ∅  this policy does not prevent password reuse

```

Sample Success Output (Manually Tested)
```

  aws_iam_password_policy prevent_password_reuse?
     ✔  should equal true
  aws_iam_password_policy number_of_passwords_to_remember
     ✔  should eq 1
```