### PR TITLE
Remove Unneeded Require Statement

### DIFF
--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -1,7 +1,5 @@
 # author: Christoph Hartmann
 
-require 'aws_conn'
-
 class Ec2 < Inspec.resource(1)
   name 'aws_ec2'
   desc 'Verifies settings for an EC2 instance'


### PR DESCRIPTION
I think this was needed back in https://github.com/chef/inspec-aws/commit/46b65ba490e1c6d46cb9845e8eeea28c896347bc#diff-7be4cd6ebd09c170768d51983b8c7d44 but is no longer required since connection is handled in `aws_conn.rb`