### PR TITLE
[ISSUE-39] - Cover Recommendation 1.12

### DIFF
--- a/libraries/aws_iam_root_user.rb
+++ b/libraries/aws_iam_root_user.rb
@@ -17,7 +17,7 @@ class AwsIamRootUser < Inspec.resource(1)
   end
 
   def to_s
-    'IAM Root User'
+    'AWS Root-User'
   end
 
   private

--- a/libraries/aws_iam_root_user.rb
+++ b/libraries/aws_iam_root_user.rb
@@ -1,0 +1,24 @@
+# author: Miles Tjandrawidjaja
+class AwsIamRootUser < Inspec.resource(1)
+  name 'aws_iam_root_user'
+  desc 'Verifies settings for AWS root account'
+  example "
+    describe aws_iam_root_user do
+      its('access_key_count') { should eq 0 }
+    end
+  "
+
+  def initialize(conn = AWSConnection.new)
+    @client = conn.iam_client
+  end
+
+  def access_key_count
+    summary_account['AccountAccessKeysPresent']
+  end
+
+  private
+
+  def summary_account
+    @summary_account ||= @client.get_account_summary.summary_map
+  end
+end

--- a/libraries/aws_iam_root_user.rb
+++ b/libraries/aws_iam_root_user.rb
@@ -16,6 +16,10 @@ class AwsIamRootUser < Inspec.resource(1)
     summary_account['AccountAccessKeysPresent']
   end
 
+  def to_s
+    'IAM Root User'
+  end
+
   private
 
   def summary_account

--- a/test/unit/resources/aws_iam_root_user_test.rb
+++ b/test/unit/resources/aws_iam_root_user_test.rb
@@ -1,0 +1,20 @@
+# author: Miles Tjandrawidjaja
+require 'helper'
+require 'aws_iam_root_user'
+
+class AwsIamRootUserTest < Minitest::Test
+  def setup
+    @mockConn = Minitest::Mock.new
+    @mockClient = Minitest::Mock.new
+
+    @mockConn.expect :iam_client, @mockClient
+  end
+
+  def test_access_key_count_returns_from_summary_account
+    expectedKeys = 2
+    summaryMap = OpenStruct.new(summary_map: {'AccountAccessKeysPresent' => expectedKeys})
+    @mockClient.expect :get_account_summary, summaryMap
+
+    assert_equal expectedKeys, AwsIamRootUser.new(@mockConn).access_key_count
+  end
+end


### PR DESCRIPTION
## Summary - Addresses https://github.com/chef/inspec-aws/issues/39
* Adding resource aws_iam_root_user
* Not sure if an integration test should be added, since it is unlikley we will use a root account to setup a test environment. **Looking for advice here**

Sample Test
```
describe aws_iam_root_user do
  its('access_key_count') { should eq 0 }
end
```

Sample Output
```
AWS Root-User
   ✔  access_key_count should eq 0
```