### PR TITLE
Run linter on unit tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ AllCops:
   Exclude:
   - Gemfile
   - Rakefile
-  - 'test/**/*'
+  - 'test/integration/**/*'
   - 'examples/**/*'
   - 'vendor/**/*'
   - 'lib/bundles/inspec-init/templates/**/*'

--- a/test/unit/resources/aws_iam_access_key_test.rb
+++ b/test/unit/resources/aws_iam_access_key_test.rb
@@ -6,9 +6,9 @@ require 'helper'
 require 'aws_iam_access_key'
 
 class AwsIamAccessKeyTest < Minitest::Test
-  Username = 'test' 
-  Id = 'id'
-  Date = 'date'
+  Username = 'test'.freeze
+  Id = 'id'.freeze
+  Date = 'date'.freeze
 
   module AccessKeyFactory
     def aws_iam_access_key(decorator = mock_decorator(stub_access_key))
@@ -16,17 +16,18 @@ class AwsIamAccessKeyTest < Minitest::Test
     end
 
     def stub_access_key(
-      _nil: false,
       id: Id,
       status: 'Active',
       create_date: Date
     )
-      OpenStruct.new({
-        :nil? => _nil,
-        :access_key_id => id,
-        :status => status,
-        :create_date => create_date
-      })
+      OpenStruct.new(
+        {
+          nil?: nil,
+          access_key_id: id,
+          status: status,
+          create_date: create_date,
+        },
+      )
     end
   end
 
@@ -64,7 +65,8 @@ class AwsIamAccessKeyTest < Minitest::Test
 
   def test_exists_returns_false_when_sdk_raises
     mock_decorator = mock_decorator_raise(
-      Aws::IAM::Errors::NoSuchEntity.new(nil, nil))
+      Aws::IAM::Errors::NoSuchEntity.new(nil, nil),
+    )
 
     refute aws_iam_access_key(mock_decorator).exists?
 
@@ -73,7 +75,8 @@ class AwsIamAccessKeyTest < Minitest::Test
 
   def test_exists_returns_false_when_access_key_does_not_exist
     mock_decorator = mock_decorator_raise(
-      AwsIamAccessKey::AccessKeyNotFoundError.new)
+      AwsIamAccessKey::AccessKeyNotFoundError.new,
+    )
 
     refute aws_iam_access_key(mock_decorator).exists?
 
@@ -100,8 +103,12 @@ class AwsIamAccessKeyTest < Minitest::Test
   def test_last_used_date_returns_last_used_date_always
     assert_equal(
       Date,
-      aws_iam_access_key(mock_decorator(nil,
-        OpenStruct.new({ :last_used_date => Date }))).last_used_date
+      aws_iam_access_key(
+        mock_decorator(
+          nil,
+          OpenStruct.new({ last_used_date: Date }),
+        ),
+      ).last_used_date,
     )
   end
 
@@ -110,7 +117,7 @@ class AwsIamAccessKeyTest < Minitest::Test
 
     def test_get_access_key_raises_when_no_access_keys_found
       validator = mock_validator
-      
+
       e = assert_raises AwsIamAccessKey::AccessKeyNotFoundError do
         iam_client_decorator(validator).get_access_key(Username, Id)
       end
@@ -124,10 +131,12 @@ class AwsIamAccessKeyTest < Minitest::Test
 
     def test_get_access_key_raises_when_matching_access_key_not_found
       validator = mock_validator
-      
-      e = assert_raises AwsIamAccessKey::AccessKeyNotFoundError do 
-        iam_client_decorator(validator, [stub_access_key(id: 'Foo')])
-          .get_access_key(Username, Id)
+
+      e = assert_raises AwsIamAccessKey::AccessKeyNotFoundError do
+        iam_client_decorator(
+          validator,
+          [stub_access_key(id: 'Foo')],
+        ).get_access_key(Username, Id)
       end
 
       assert_match(/.*access key not found.*/, e.message)
@@ -143,7 +152,10 @@ class AwsIamAccessKeyTest < Minitest::Test
 
       assert_equal(
         access_key,
-        iam_client_decorator(validator, [access_key]).get_access_key(Username, Id)
+        iam_client_decorator(
+          validator,
+          [access_key],
+        ).get_access_key(Username, Id),
       )
 
       validator.verify
@@ -155,8 +167,11 @@ class AwsIamAccessKeyTest < Minitest::Test
 
       assert_equal(
         access_key_last_used,
-        iam_client_decorator(validator, nil, access_key_last_used)
-          .get_access_key_last_used(Id)
+        iam_client_decorator(
+          validator,
+          nil,
+          access_key_last_used,
+        ).get_access_key_last_used(Id),
       )
 
       validator.verify
@@ -165,9 +180,9 @@ class AwsIamAccessKeyTest < Minitest::Test
     class ArgumentValidatorTest < Minitest::Test
       def test_validate_id_raises_when_id_is_nil
         argument_validator.validate_id(nil)
-	flunk
+        flunk
       rescue ArgumentError => e
-	assert_match(/.*missing.*"id".*/, e.message)
+        assert_match(/.*missing.*"id".*/, e.message)
       end
 
       def test_validate_id_does_nothing_when_id_is_not_nil
@@ -175,18 +190,18 @@ class AwsIamAccessKeyTest < Minitest::Test
       end
 
       def test_validate_username_raises_when_username_is_nil
-	argument_validator.validate_username(nil)
-	flunk
+        argument_validator.validate_username(nil)
+        flunk
       rescue ArgumentError => e
-	assert_match(/.*missing.*"username".*/, e.message)
+        assert_match(/.*missing.*"username".*/, e.message)
       end
 
       def test_validate_username_does_nothing_when_username_is_not_nil
-        argument_validator.validate_username(Username) 
+        argument_validator.validate_username(Username)
       end
 
       def argument_validator
-	AwsIamAccessKey::IamClientDecorator::ArgumentValidator.new
+        AwsIamAccessKey::IamClientDecorator::ArgumentValidator.new
       end
     end
 
@@ -203,7 +218,7 @@ class AwsIamAccessKeyTest < Minitest::Test
     def mock_conn(access_keys, access_key_last_used = nil)
       Minitest::Mock.new.expect(
         :iam_client,
-        mock_client(access_keys, access_key_last_used)
+        mock_client(access_keys, access_key_last_used),
       )
     end
 
@@ -213,25 +228,30 @@ class AwsIamAccessKeyTest < Minitest::Test
       if access_keys
         mock_iam_client.expect(
           :list_access_keys,
-          OpenStruct.new({'access_key_metadata' => access_keys}),
-          [{user_name: Username}]
+          OpenStruct.new({ 'access_key_metadata' => access_keys }),
+          [{ user_name: Username }],
         )
       end
 
       if access_key_last_used
         mock_iam_client.expect(
           :get_access_key_last_used,
-          OpenStruct.new({'access_key_last_used' => access_key_last_used}),
-          [{access_key_id: Id}]
+          OpenStruct.new({ 'access_key_last_used' => access_key_last_used }),
+          [{ access_key_id: Id }],
         )
       end
 
       mock_iam_client
     end
 
-    def iam_client_decorator(validator, access_keys = [], access_key_last_used = nil)
+    def iam_client_decorator(
+      validator,
+      access_keys = [],
+      access_key_last_used = nil
+    )
       AwsIamAccessKey::IamClientDecorator.new(
-        validator, mock_conn(access_keys, access_key_last_used))
+        validator, mock_conn(access_keys, access_key_last_used)
+      )
     end
   end
 
@@ -243,7 +263,11 @@ class AwsIamAccessKeyTest < Minitest::Test
     end
 
     if access_key_last_used
-      mock_decorator.expect :get_access_key_last_used, access_key_last_used, [Id]
+      mock_decorator.expect(
+        :get_access_key_last_used,
+        access_key_last_used,
+        [Id],
+      )
     end
 
     mock_decorator
@@ -252,7 +276,7 @@ class AwsIamAccessKeyTest < Minitest::Test
   def mock_decorator_raise(error)
     Minitest::Mock.new.expect(:get_access_key, nil) do |username, id|
       assert_equal Username, username
-      assert_equal Id, id  
+      assert_equal Id, id
 
       raise error
     end

--- a/test/unit/resources/aws_iam_access_key_test.rb
+++ b/test/unit/resources/aws_iam_access_key_test.rb
@@ -36,27 +36,32 @@ class AwsIamAccessKeyTest < Minitest::Test
   def test_initialize_accepts_fields
     assert_equal(
       Id,
-      AwsIamAccessKey.new({id: Id, username: Username}, nil)
-        .instance_variable_get('@id')
-    );
+      AwsIamAccessKey.new({ id: Id, username: Username }, nil)
+        .instance_variable_get('@id'),
+    )
   end
 
   def test_initialize_accepts_access_key
     assert_equal(
       Id,
-      AwsIamAccessKey.new({access_key: OpenStruct.new(access_key_id: Id)}, nil)
-        .instance_variable_get('@id')
-    );
+      AwsIamAccessKey.new(
+        {
+          access_key: OpenStruct.new(access_key_id: Id),
+        }, nil
+      ).instance_variable_get('@id'),
+    )
   end
 
   def test_initialize_prefers_access_key
     assert_equal(
       Id,
-      AwsIamAccessKey.new({
-        id: 'foo',
-        access_key: OpenStruct.new(access_key_id: Id)
-      }, nil).instance_variable_get('@id')
-    );
+      AwsIamAccessKey.new(
+        {
+          id: 'foo',
+          access_key: OpenStruct.new(access_key_id: Id),
+        }, nil
+      ).instance_variable_get('@id'),
+    )
   end
 
   def test_exists_returns_true_when_access_key_exists

--- a/test/unit/resources/aws_iam_password_policy_test.rb
+++ b/test/unit/resources/aws_iam_password_policy_test.rb
@@ -60,22 +60,25 @@ class AwsIamPasswordPolicyTest < Minitest::Test
   end
 
   def test_number_of_passwords_to_remember_returns_configured_value
-    expectedValue = 5
-    configure_policy_password_reuse_prevention(value: expectedValue, n: 2)
+    expected_value = 5
+    configure_policy_password_reuse_prevention(value: expected_value, n: 2)
 
-    assert_equal expectedValue, AwsIamPasswordPolicy.new(@mock_conn).number_of_passwords_to_remember
+    assert_equal(
+      expected_value,
+      AwsIamPasswordPolicy.new(@mock_conn).number_of_passwords_to_remember,
+    )
   end
 
   def test_policy_to_s
     configure_policy_password_reuse_prevention(value: Object.new)
-    expectedValue = "IAM Password-Policy"
+    expected_value = 'IAM Password-Policy'
     test = AwsIamPasswordPolicy.new(@mock_conn).to_s
-    assert_equal expectedValue, test
+    assert_equal expected_value, test
   end
 
-  private 
+  private
 
-  def configure_policy_password_reuse_prevention(value: value, n: 1)
+  def configure_policy_password_reuse_prevention(value: value=nil, n: 1)
     n.times { @mock_policy.expect :password_reuse_prevention, value }
     @mock_resource.expect :account_password_policy, @mock_policy
   end

--- a/test/unit/resources/aws_iam_password_policy_test.rb
+++ b/test/unit/resources/aws_iam_password_policy_test.rb
@@ -5,33 +5,33 @@ require 'json'
 
 class AwsIamPasswordPolicyTest < Minitest::Test
   def setup
-    @mockConn = Minitest::Mock.new
-    @mockResource = Minitest::Mock.new
-    @mockPolicy = Minitest::Mock.new
+    @mock_conn = Minitest::Mock.new
+    @mock_resource = Minitest::Mock.new
+    @mock_policy = Minitest::Mock.new
 
-    @mockConn.expect :iam_resource, @mockResource
+    @mock_conn.expect :iam_resource, @mock_resource
   end
 
   def test_policy_exists_when_policy_exists
-    @mockResource.expect :account_password_policy, true
+    @mock_resource.expect :account_password_policy, true
 
-    assert_equal true, AwsIamPasswordPolicy.new(@mockConn).exists?
+    assert_equal true, AwsIamPasswordPolicy.new(@mock_conn).exists?
   end
 
   def test_policy_does_not_exists_when_no_policy
-    @mockResource.expect :account_password_policy, nil do |args|
+    @mock_resource.expect :account_password_policy, nil do
       raise Aws::IAM::Errors::NoSuchEntity.new nil, nil
     end
 
-    assert_equal false, AwsIamPasswordPolicy.new(@mockConn).exists?
+    assert_equal false, AwsIamPasswordPolicy.new(@mock_conn).exists?
   end
 
   def test_throws_when_password_age_0
-    @mockPolicy.expect :expire_passwords, false
-    @mockResource.expect :account_password_policy, @mockPolicy
+    @mock_policy.expect :expire_passwords, false
+    @mock_resource.expect :account_password_policy, @mock_policy
 
     e = assert_raises Exception do
-      AwsIamPasswordPolicy.new(@mockConn).max_password_age
+      AwsIamPasswordPolicy.new(@mock_conn).max_password_age
     end
 
     assert_equal e.message, 'this policy does not expire passwords'
@@ -40,20 +40,20 @@ class AwsIamPasswordPolicyTest < Minitest::Test
   def test_prevents_password_reuse_returns_true_when_not_nil
     configure_policy_password_reuse_prevention(value: Object.new)
 
-    assert AwsIamPasswordPolicy.new(@mockConn).prevents_password_reuse?
+    assert AwsIamPasswordPolicy.new(@mock_conn).prevents_password_reuse?
   end
 
   def test_prevents_password_reuse_returns_false_when_nil
     configure_policy_password_reuse_prevention(value: nil)
 
-    refute AwsIamPasswordPolicy.new(@mockConn).prevents_password_reuse?
+    refute AwsIamPasswordPolicy.new(@mock_conn).prevents_password_reuse?
   end
 
   def test_number_of_passwords_to_remember_throws_when_nil
     configure_policy_password_reuse_prevention(value: nil)
 
     e = assert_raises Exception do
-      AwsIamPasswordPolicy.new(@mockConn).number_of_passwords_to_remember
+      AwsIamPasswordPolicy.new(@mock_conn).number_of_passwords_to_remember
     end
 
     assert_equal e.message, 'this policy does not prevent password reuse'
@@ -63,20 +63,20 @@ class AwsIamPasswordPolicyTest < Minitest::Test
     expectedValue = 5
     configure_policy_password_reuse_prevention(value: expectedValue, n: 2)
 
-    assert_equal expectedValue, AwsIamPasswordPolicy.new(@mockConn).number_of_passwords_to_remember
+    assert_equal expectedValue, AwsIamPasswordPolicy.new(@mock_conn).number_of_passwords_to_remember
   end
 
   def test_policy_to_s
     configure_policy_password_reuse_prevention(value: Object.new)
     expectedValue = "IAM Password-Policy"
-    test = AwsIamPasswordPolicy.new(@mockConn).to_s
+    test = AwsIamPasswordPolicy.new(@mock_conn).to_s
     assert_equal expectedValue, test
   end
 
   private 
 
   def configure_policy_password_reuse_prevention(value: value, n: 1)
-    n.times { @mockPolicy.expect :password_reuse_prevention, value }
-    @mockResource.expect :account_password_policy, @mockPolicy
+    n.times { @mock_policy.expect :password_reuse_prevention, value }
+    @mock_resource.expect :account_password_policy, @mock_policy
   end
 end

--- a/test/unit/resources/aws_iam_root_user_test.rb
+++ b/test/unit/resources/aws_iam_root_user_test.rb
@@ -4,17 +4,19 @@ require 'aws_iam_root_user'
 
 class AwsIamRootUserTest < Minitest::Test
   def setup
-    @mockConn = Minitest::Mock.new
-    @mockClient = Minitest::Mock.new
+    @mock_conn = Minitest::Mock.new
+    @mock_client = Minitest::Mock.new
 
-    @mockConn.expect :iam_client, @mockClient
+    @mock_conn.expect :iam_client, @mock_client
   end
 
   def test_access_key_count_returns_from_summary_account
-    expectedKeys = 2
-    summaryMap = OpenStruct.new(summary_map: {'AccountAccessKeysPresent' => expectedKeys})
-    @mockClient.expect :get_account_summary, summaryMap
+    expected_keys = 2
+    test_summary_map = OpenStruct.new(
+      summary_map: { 'AccountAccessKeysPresent' => expected_keys },
+    )
+    @mock_client.expect :get_account_summary, test_summary_map
 
-    assert_equal expectedKeys, AwsIamRootUser.new(@mockConn).access_key_count
+    assert_equal expected_keys, AwsIamRootUser.new(@mock_conn).access_key_count
   end
 end

--- a/test/unit/resources/aws_iam_user_provider_test.rb
+++ b/test/unit/resources/aws_iam_user_provider_test.rb
@@ -8,7 +8,7 @@ require 'helper'
 require 'aws_iam_user_provider'
 
 class AwsIamUserProviderTest < Minitest::Test
-  Username = "test"
+  Username = 'test'.freeze
 
   def setup
     @mock_iam_resource = Minitest::Mock.new
@@ -23,9 +23,16 @@ class AwsIamUserProviderTest < Minitest::Test
   end
 
   def test_list_users
-    @mock_iam_resource.expect :users, [create_mock_user, create_mock_user, create_mock_user]
-    mock_user_output = {has_mfa_enabled?: true, has_console_password?: true, access_keys: []}
-    assert @user_provider.list_users == [mock_user_output, mock_user_output, mock_user_output]
+    @mock_iam_resource.expect(
+      :users,
+      [create_mock_user, create_mock_user, create_mock_user],
+    )
+    mock_user_output = { has_mfa_enabled?: true, has_console_password?: true,  access_keys: [] }
+    assert @user_provider.list_users == [
+      mock_user_output,
+      mock_user_output,
+      mock_user_output,
+    ]
   end
 
   def test_list_users_no_users
@@ -34,34 +41,57 @@ class AwsIamUserProviderTest < Minitest::Test
   end
 
   def test_has_mfa_enabled_returns_true
-    @mock_iam_resource.expect :user, create_mock_user(has_mfa_enabled: true), [Username]
+    @mock_iam_resource.expect(
+      :user,
+      create_mock_user(has_mfa_enabled: true),
+      [Username],
+    )
     assert @user_provider.user(Username)[:has_mfa_enabled?]
   end
 
   def test_has_mfa_enabled_returns_false
-    @mock_iam_resource.expect :user, create_mock_user(has_mfa_enabled: false), [Username]
+    @mock_iam_resource.expect(
+      :user,
+      create_mock_user(has_mfa_enabled: false),
+      [Username],
+    )
     assert !@user_provider.user(Username)[:has_mfa_enabled?]
   end
-  
+
   def test_has_console_password_returns_true
-    @mock_iam_resource.expect :user, create_mock_user(has_console_password: true), [Username]
+    @mock_iam_resource.expect(
+      :user,
+      create_mock_user(has_console_password: true),
+      [Username],
+    )
     assert @user_provider.user(Username)[:has_console_password?]
   end
 
   def test_has_console_password_returns_false
-    @mock_iam_resource.expect :user, create_mock_user(has_console_password: false), [Username]
+    @mock_iam_resource.expect(
+      :user,
+      create_mock_user(has_console_password: false),
+      [Username],
+    )
     assert !@user_provider.user(Username)[:has_console_password?]
   end
-  
+
   def test_has_console_password_returns_false_when_nosuchentity
-    @mock_iam_resource.expect :user, create_mock_user_throw(Aws::IAM::Errors::NoSuchEntity.new(nil, nil)), [Username]
-    
+    @mock_iam_resource.expect(
+      :user,
+      create_mock_user_throw(Aws::IAM::Errors::NoSuchEntity.new(nil, nil)),
+      [Username],
+    )
     assert !@user_provider.user(Username)[:has_console_password?]
   end
-  
+
   def test_has_console_password_throws
-    @mock_iam_resource.expect :user, create_mock_user_throw(ArgumentError), [Username]
-    
+    @mock_iam_resource.expect(
+      :user,
+      create_mock_user_throw(ArgumentError),
+      [Username],
+    )
+
     assert_raises ArgumentError do
       @user_provider.user(Username)
     end
@@ -86,7 +116,7 @@ class AwsIamUserProviderTest < Minitest::Test
     mock_user.expect :login_profile, mock_login_profile
     mock_user.expect :access_keys, access_keys
   end
-  
+
   def create_mock_user_throw(exception)
     mock_login_profile = Minitest::Mock.new
     mock_login_profile.expect :create_date, nil do |args|

--- a/test/unit/resources/aws_iam_user_provider_test.rb
+++ b/test/unit/resources/aws_iam_user_provider_test.rb
@@ -4,7 +4,6 @@
 # author: Alex Bedley
 require 'aws-sdk'
 require 'helper'
-
 require 'aws_iam_user_provider'
 
 class AwsIamUserProviderTest < Minitest::Test
@@ -27,12 +26,13 @@ class AwsIamUserProviderTest < Minitest::Test
       :users,
       [create_mock_user, create_mock_user, create_mock_user],
     )
-    mock_user_output = { has_mfa_enabled?: true, has_console_password?: true,  access_keys: [] }
-    assert @user_provider.list_users == [
-      mock_user_output,
-      mock_user_output,
-      mock_user_output,
-    ]
+    mock_user_output = {
+      has_mfa_enabled?: true,
+      has_console_password?: true,
+      access_keys: [],
+    }
+    assert @user_provider.list_users == [mock_user_output, mock_user_output,
+                                         mock_user_output]
   end
 
   def test_list_users_no_users
@@ -41,20 +41,14 @@ class AwsIamUserProviderTest < Minitest::Test
   end
 
   def test_has_mfa_enabled_returns_true
-    @mock_iam_resource.expect(
-      :user,
-      create_mock_user(has_mfa_enabled: true),
-      [Username],
-    )
+    @mock_iam_resource.expect(:user, create_mock_user(has_mfa_enabled: true),
+                              [Username])
     assert @user_provider.user(Username)[:has_mfa_enabled?]
   end
 
   def test_has_mfa_enabled_returns_false
-    @mock_iam_resource.expect(
-      :user,
-      create_mock_user(has_mfa_enabled: false),
-      [Username],
-    )
+    @mock_iam_resource.expect(:user, create_mock_user(has_mfa_enabled: false),
+                              [Username])
     assert !@user_provider.user(Username)[:has_mfa_enabled?]
   end
 
@@ -86,11 +80,8 @@ class AwsIamUserProviderTest < Minitest::Test
   end
 
   def test_has_console_password_throws
-    @mock_iam_resource.expect(
-      :user,
-      create_mock_user_throw(ArgumentError),
-      [Username],
-    )
+    @mock_iam_resource.expect(:user, create_mock_user_throw(ArgumentError),
+                              [Username])
 
     assert_raises ArgumentError do
       @user_provider.user(Username)
@@ -99,18 +90,22 @@ class AwsIamUserProviderTest < Minitest::Test
 
   def test_access_keys_returns_access_keys
     access_key = Object.new
-
-    @mock_iam_resource.expect :user, create_mock_user(access_keys: [access_key]), [Username]
+    @mock_iam_resource.expect(
+      :user,
+      create_mock_user(access_keys: [access_key]),
+      [Username],
+    )
 
     assert_equal [access_key], @user_provider.user(Username)[:access_keys]
   end
 
   private
 
-  def create_mock_user(has_console_password: true, has_mfa_enabled: true, access_keys: [])
+  def create_mock_user(has_console_password: true, has_mfa_enabled: true,
+                       access_keys: [])
     mock_login_profile = Minitest::Mock.new
     mock_login_profile.expect :create_date, has_console_password ? 'date' : nil
-    
+
     mock_user = Minitest::Mock.new
     mock_user.expect :mfa_devices, has_mfa_enabled ? ['device'] : []
     mock_user.expect :login_profile, mock_login_profile
@@ -119,10 +114,10 @@ class AwsIamUserProviderTest < Minitest::Test
 
   def create_mock_user_throw(exception)
     mock_login_profile = Minitest::Mock.new
-    mock_login_profile.expect :create_date, nil do |args|
+    mock_login_profile.expect :create_date, nil do
       raise exception
     end
-    
+
     mock_user = Minitest::Mock.new
     mock_user.expect :mfa_devices, []
     mock_user.expect :login_profile, mock_login_profile

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -1,33 +1,48 @@
 # author: Simon Varlow
 require 'aws-sdk'
 require 'helper'
-
 require 'aws_iam_user'
 
 class AwsIamUserTest < Minitest::Test
-  Username = "test" 
-  
+  Username = 'test'.freeze
+
   def setup
     @mock_user_provider = Minitest::Mock.new
   end
 
-  def test_that_MFA_enable_returns_true_if_MFA_Enabled
-    @mock_user_provider.expect :user, {has_mfa_enabled?: true}, [Username]
+  def test_mfa_enabled_returns_true_if_mfa_enabled
+    @mock_user_provider.expect(
+      :user,
+      { has_mfa_enabled?: true },
+      [Username],
+    )
     assert AwsIamUser.new(Username, @mock_user_provider).has_mfa_enabled?
   end
 
-  def test_that_MFA_enable_returns_false_if_MFA_is_not_Enabled
-    @mock_user_provider.expect :user, {has_mfa_enabled?: false}, [Username]
+  def test_mfa_enabled_returns_false_if_mfa_is_not_enabled
+    @mock_user_provider.expect(
+      :user,
+      { has_mfa_enabled?: false },
+      [Username],
+    )
     refute AwsIamUser.new(Username, @mock_user_provider).has_mfa_enabled?
   end
 
-  def test_that_console_Password_returns_true_if_console_Password_has_been_set
-    @mock_user_provider.expect :user, {has_console_password?: true}, [Username]
+  def test_console_password_returns_true_if_console_password_has_been_set
+    @mock_user_provider.expect(
+      :user,
+      { has_console_password?: true },
+      [Username],
+    )
     assert AwsIamUser.new(Username, @mock_user_provider).has_console_password?
   end
 
-  def test_that_console_Password_returns_false_if_console_Password_has_not_been_set
-    @mock_user_provider.expect :user, {has_console_password?: false}, [Username]
+  def test_console_password_returns_false_if_console_password_has_not_been_set
+    @mock_user_provider.expect(
+      :user,
+      { has_console_password?: false },
+      [Username],
+    )
     refute AwsIamUser.new(Username, @mock_user_provider).has_console_password?
   end
 

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -51,18 +51,32 @@ class AwsIamUserTest < Minitest::Test
     stub_access_key_resource = Object.new
     mock_access_key_factory = Minitest::Mock.new
 
-    @mock_user_provider.expect :user, {access_keys: [stub_aws_access_key]}, [Username]
-    mock_access_key_factory.expect :create_access_key, stub_access_key_resource, [stub_aws_access_key]
+    @mock_user_provider.expect(
+      :user,
+      { access_keys: [stub_aws_access_key] },
+      [Username],
+    )
+    mock_access_key_factory.expect(
+      :create_access_key,
+      stub_access_key_resource,
+      [stub_aws_access_key],
+    )
 
-    assert_equal(stub_access_key_resource,
-                 AwsIamUser.new(Username, @mock_user_provider, mock_access_key_factory).access_keys[0])
+    assert_equal(
+      stub_access_key_resource,
+      AwsIamUser.new(
+        Username,
+        @mock_user_provider,
+        mock_access_key_factory,
+      ).access_keys[0],
+    )
 
     mock_access_key_factory.verify
   end
 
   def test_to_s
-    @mock_user_provider.expect :user, {has_mfa_enabled?: true}, [Username]
-    expected = "IAM User test"
+    @mock_user_provider.expect :user, { has_mfa_enabled?: true }, [Username]
+    expected = 'IAM User test'
     test = AwsIamUser.new(Username, @mock_user_provider).to_s
     assert_equal expected, test
   end

--- a/test/unit/resources/ec2_test.rb
+++ b/test/unit/resources/ec2_test.rb
@@ -1,60 +1,53 @@
 require 'helper'
-
 require 'ec2'
 
 class TestEc2 < Minitest::Test
-  Id = "instance-id"
+  Id = 'instance-id'.freeze
 
   def setup
-    @mockConn = Minitest::Mock.new
-    @mockClient = Minitest::Mock.new
-    @mockResource = Minitest::Mock.new
+    @mock_conn = Minitest::Mock.new
+    @mock_client = Minitest::Mock.new
+    @mock_resource = Minitest::Mock.new
 
-    @mockConn.expect :ec2_client, @mockClient
-    @mockConn.expect :ec2_resource, @mockResource
+    @mock_conn.expect :ec2_client, @mock_client
+    @mock_conn.expect :ec2_resource, @mock_resource
   end
 
   def test_that_id_returns_id_directly_when_constructed_with_an_id
-    assert_equal Id, Ec2.new(Id, @mockConn).id
+    assert_equal Id, Ec2.new(Id, @mock_conn).id
   end
 
   def test_that_id_returns_fetched_id_when_constructed_with_a_name
-    mockInstance = Minitest::Mock.new
-
-    mockInstance.expect :nil?, false
-    mockInstance.expect :id, Id
-    @mockResource.expect :instances, [mockInstance], [Hash]
-     
-    assert_equal Id, Ec2.new({name: 'cut'}, @mockConn).id
+    mock_instance = Minitest::Mock.new
+    mock_instance.expect :nil?, false
+    mock_instance.expect :id, Id
+    @mock_resource.expect :instances, [mock_instance], [Hash]
+    assert_equal Id, Ec2.new({ name: 'cut' }, @mock_conn).id
   end
 
   def test_that_instance_returns_instance_when_instance_exists
-    mockInstance = Object.new
+    mock_instance = Object.new
 
-    @mockResource.expect :instance, mockInstance, [Id] 
-
-    assert_same mockInstance, Ec2.new(Id, @mockConn).send(:instance)
+    @mock_resource.expect :instance, mock_instance, [Id]
+    assert_same mock_instance, Ec2.new(Id, @mock_conn).send(:instance)
   end
 
   def test_that_instance_returns_nil_when_instance_does_not_exist
-    @mockResource.expect :instance, nil, [Id] 
-
-    assert Ec2.new(Id, @mockConn).send(:instance).nil?
+    @mock_resource.expect :instance, nil, [Id]
+    assert Ec2.new(Id, @mock_conn).send(:instance).nil?
   end
 
   def test_that_exists_returns_true_when_instance_exists
-    mockInstance = Minitest::Mock.new
-    mockInstance.expect :exists?, true
-    @mockResource.expect :instance, mockInstance, [Id] 
-
-    assert Ec2.new(Id, @mockConn).exists?
+    mock_instance = Minitest::Mock.new
+    mock_instance.expect :exists?, true
+    @mock_resource.expect :instance, mock_instance, [Id]
+    assert Ec2.new(Id, @mock_conn).exists?
   end
 
   def test_that_exists_returns_false_when_instance_does_not_exist
-    mockInstance = Minitest::Mock.new
-    mockInstance.expect :exists?, false
-    @mockResource.expect :instance, mockInstance, [Id]
-
-    assert !Ec2.new(Id, @mockConn).exists?
+    mock_instance = Minitest::Mock.new
+    mock_instance.expect :exists?, false
+    @mock_resource.expect :instance, mock_instance, [Id]
+    assert !Ec2.new(Id, @mock_conn).exists?
   end
 end


### PR DESCRIPTION
I realized Rubocop wasn't running on the unit tests and felt like that was something that was missing. I've updated the rubocop.yml so instead of ignoring everything under the test directory, it only ignores the integration tests.

I've updated the existing unit tests to adhere to the rubocop standards.
Signed-off-by: sfreeman <Steffanie.Freeman@d2l.com>