### PR TITLE
Add to_s method to aws_iam_user

### DIFF
--- a/libraries/aws_iam_user.rb
+++ b/libraries/aws_iam_user.rb
@@ -34,6 +34,10 @@ class AwsIamUser < Inspec.resource(1)
     }
   end
 
+  def to_s
+    "IAM User #{@name}"
+  end
+
   class AwsIamAccessKeyFactory
     def create_access_key(access_key)
       AwsIamAccessKey.new({ access_key: access_key })

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -44,4 +44,11 @@ class AwsIamUserTest < Minitest::Test
 
     mock_access_key_factory.verify
   end
+
+  def test_to_s
+    @mock_user_provider.expect :user, {has_mfa_enabled?: true}, [Username]
+    expected = "IAM User test"
+    test = AwsIamUser.new(Username, @mock_user_provider).to_s
+    assert_equal expected, test
+  end
 end


### PR DESCRIPTION
Signed-off-by: sfreeman <Steffanie.Freeman@d2l.com>

We decided to use the value of `name` as our user identifier, let us know if you want to change that!