### PR TITLE
Use proper resource name in sample code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ AllCops:
   Exclude:
   - Gemfile
   - Rakefile
-  - 'test/**/*'
+  - 'test/integration/**/*'
   - 'examples/**/*'
   - 'vendor/**/*'
   - 'lib/bundles/inspec-init/templates/**/*'

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ control "aws-1" do
   impact 0.7
   title 'Checks the machine is running'
 
-  describe ec2('my-ec2-machine') do
+  describe aws_ec2('my-ec2-machine') do
     it { should be_running }
   end
 end

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ end
 ### Available Resources
 
  * `aws_ec2` - This resource reads information about an ec2 instance
+ * `aws_iam_access_key` - Verifies settings for AWS IAM access keys
+ * `aws_iam_password_policy` - Verifies iam password policy
+ * `aws_iam_root_user` - Verifies settings for AWS root account
+ * `aws_iam_user` - Verifies settings for a specific AWS IAM user
+ * `aws_iam_users` - Verifies settings for AWS IAM users
 
 ### Roadmap
 
@@ -71,7 +76,6 @@ end
  * `aws_iam_group`
  * `aws_iam_policy`
  * `aws_iam_role`
- * `aws_iam_user`
  ...
 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ As of now, AWS resources are implemented as an InSpec resource pack. It will shi
 
 To run the profile, use InSpec with an environment variable for AWS credentials:
 
-- `AWS_DEFAULT_REGION`
+- `AWS_REGION`
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 
@@ -92,7 +92,7 @@ bundle exec rake test
 ### Integration tests
 
 To run the integration tests, please make sure all required environment variables like `AWS_ACCESS_KEY_ID`
-, `AWS_SECRET_ACCESS_KEY` and `AWS_DEFAULT_REGION` are set properly. (`AWS_DEFAULT_REGION` **must** be set to **us-east-1** when running the integration tests.) We use terraform to create the AWS setup and InSpec to verify the all aspects. If you want to use a specific terraform environment, set environment variable `INSPEC_TERRAFORM_ENV`. Integration tests can be executed via:
+, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION` are set properly. (`AWS_REGION` **must** be set to **us-east-1** when running the integration tests.) We use terraform to create the AWS setup and InSpec to verify the all aspects. If you want to use a specific terraform environment, set environment variable `INSPEC_TERRAFORM_ENV`. Integration tests can be executed via:
 
 ```
 bundle exec rake test:integration

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ control "aws-1" do
   impact 0.7
   title 'Checks the machine is running'
 
-  describe aws_ec2('my-ec2-machine') do
+  describe aws_ec2('i-my-ec2-instance-id') do
     it { should be_running }
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -75,11 +75,16 @@ namespace :test do
 
   task :integration do
     namespace = ENV['INSPEC_TERRAFORM_ENV'] || prompt("Please enter a namespace for your integration tests to run in: ")
-    Rake::Task["test:configure_test_environment"].execute({:namespace => namespace})
-    Rake::Task["test:cleanup_integration_tests"].execute
-    Rake::Task["test:setup_integration_tests"].execute
-    Rake::Task["test:run_integration_tests"].execute
-    Rake::Task["test:cleanup_integration_tests"].execute
-    Rake::Task["test:destroy_test_environment"].execute({:namespace => namespace})
+    begin
+      Rake::Task["test:configure_test_environment"].execute({:namespace => namespace})
+      Rake::Task["test:cleanup_integration_tests"].execute
+      Rake::Task["test:setup_integration_tests"].execute
+      Rake::Task["test:run_integration_tests"].execute
+    rescue
+      abort("Integration testing has failed")
+    ensure
+      Rake::Task["test:cleanup_integration_tests"].execute
+      Rake::Task["test:destroy_test_environment"].execute({:namespace => namespace})
+    end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,8 @@ namespace :test do
 
   task :configure_test_environment, :namespace do |t, args|
     puts "----> Creating terraform environment"
-    sh("cd #{integration_dir}/build/ && terraform env new #{args[:namespace]}")
+    sh("cd #{integration_dir}/build/ && terraform init")
+    sh("cd #{integration_dir}/build/ && terraform workspace new #{args[:namespace]}")
   end
 
   task :setup_integration_tests do
@@ -69,8 +70,8 @@ namespace :test do
 
   task :destroy_test_environment, :namespace do |t, args|
     puts "----> Destroying terraform environment"
-    sh("cd #{integration_dir}/build/ && terraform env select default")
-    sh("cd #{integration_dir}/build && terraform env delete #{args[:namespace]}")
+    sh("cd #{integration_dir}/build/ && terraform workspace select default")
+    sh("cd #{integration_dir}/build && terraform workspace delete #{args[:namespace]}")
   end
 
   task :integration do

--- a/libraries/aws_conn.rb
+++ b/libraries/aws_conn.rb
@@ -4,7 +4,7 @@ class AWSConnection
   def initialize
     require 'aws-sdk'
     opts = {
-      region: ENV['AWS_DEFAULT_REGION'],
+      region: ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'],
       credentials: Aws::Credentials.new(
         ENV['AWS_ACCESS_KEY_ID'],
         ENV['AWS_SECRET_ACCESS_KEY'],

--- a/libraries/aws_ec2_instance.rb
+++ b/libraries/aws_ec2_instance.rb
@@ -1,7 +1,7 @@
 # author: Christoph Hartmann
 
-class Ec2 < Inspec.resource(1)
-  name 'aws_ec2'
+class AwsEc2Instance < Inspec.resource(1)
+  name 'aws_ec2_instance'
   desc 'Verifies settings for an EC2 instance'
 
   example "
@@ -41,6 +41,7 @@ class Ec2 < Inspec.resource(1)
   alias instance_id id
 
   def exists?
+    return false if instance.nil?
     instance.exists?
   end
 
@@ -67,7 +68,7 @@ class Ec2 < Inspec.resource(1)
     instance_type image_id vpc_id
   }.each do |attribute|
     define_method attribute do
-      instance.send(attribute)
+      instance.send(attribute) if instance
     end
   end
 
@@ -89,5 +90,20 @@ class Ec2 < Inspec.resource(1)
 
   def instance
     @instance ||= @ec2_resource.instance(id)
+  end
+end
+
+# Deprecated
+class AwsEc2 < AwsEc2Instance
+  name 'aws_ec2'
+
+  def initialize(opts, conn = AWSConnection.new)
+    deprecated
+    super(opts, conn)
+  end
+
+  def deprecated
+    warn '[DEPRECATION] `aws_ec2(parameter)` is deprecated. ' \
+         'Please use `aws_ec2_instance(parameter)` instead.'
   end
 end

--- a/libraries/aws_iam_password_policy.rb
+++ b/libraries/aws_iam_password_policy.rb
@@ -68,4 +68,8 @@ class AwsIamPasswordPolicy < Inspec.resource(1)
       unless prevents_password_reuse?
     @policy.password_reuse_prevention
   end
+
+  def to_s
+    'IAM Password-Policy'
+  end
 end

--- a/libraries/aws_iam_root_user.rb
+++ b/libraries/aws_iam_root_user.rb
@@ -16,6 +16,10 @@ class AwsIamRootUser < Inspec.resource(1)
     summary_account['AccountAccessKeysPresent']
   end
 
+  def has_mfa_enabled?
+    summary_account['AccountMFAEnabled'] == 1
+  end
+
   def to_s
     'AWS Root-User'
   end

--- a/libraries/aws_iam_user.rb
+++ b/libraries/aws_iam_user.rb
@@ -34,6 +34,10 @@ class AwsIamUser < Inspec.resource(1)
     }
   end
 
+  def to_s
+    "IAM User #{@name}"
+  end
+
   class AwsIamAccessKeyFactory
     def create_access_key(access_key)
       AwsIamAccessKey.new({ access_key: access_key })

--- a/libraries/aws_iam_user.rb
+++ b/libraries/aws_iam_user.rb
@@ -7,16 +7,18 @@ class AwsIamUser < Inspec.resource(1)
   name 'aws_iam_user'
   desc 'Verifies settings for AWS IAM user'
   example "
-    describe aws_iam_user('test_user_name') do
+    describe aws_iam_user(name: 'test_user_name') do
       its('has_mfa_enabled?') { should be false }
       its('has_console_password?') { should be true }
     end
   "
-  def initialize(name, aws_user_provider = AwsIam::UserProvider.new,
-                 access_key_factory = AwsIamAccessKeyFactory.new)
-
-    @name = name
-    @user = aws_user_provider.user(name)
+  def initialize(
+    opts,
+    aws_user_provider = AwsIam::UserProvider.new,
+    access_key_factory = AwsIamAccessKeyFactory.new
+  )
+    @user = opts[:user]
+    @user = aws_user_provider.user(opts[:name]) if @user.nil?
     @access_key_factory = access_key_factory
   end
 
@@ -34,8 +36,12 @@ class AwsIamUser < Inspec.resource(1)
     }
   end
 
+  def name
+    @user[:name]
+  end
+
   def to_s
-    "IAM User #{@name}"
+    "IAM User #{name}"
   end
 
   class AwsIamAccessKeyFactory

--- a/libraries/aws_iam_user_provider.rb
+++ b/libraries/aws_iam_user_provider.rb
@@ -20,6 +20,10 @@ module AwsIam
     end
 
     class << self
+      def name(aws_user)
+        aws_user.name
+      end
+
       def has_mfa_enabled?(aws_user)
         !aws_user.mfa_devices.first.nil?
       end
@@ -36,6 +40,7 @@ module AwsIam
 
       def convert(aws_user)
         {
+          name: name(aws_user),
           has_mfa_enabled?: has_mfa_enabled?(aws_user),
           has_console_password?: has_console_password?(aws_user),
           access_keys: access_keys(aws_user),

--- a/libraries/aws_iam_users.rb
+++ b/libraries/aws_iam_users.rb
@@ -1,0 +1,51 @@
+# author: Alex Bedley
+# author: Steffanie Freeman
+# author: Simon Varlow
+# author: Chris Redekop
+class AwsIamUsers < Inspec.resource(1)
+  name 'aws_iam_users'
+  desc 'Verifies settings for AWS IAM users'
+  example '
+    describe aws_iam_users.where(has_mfa_enabled?: false) do
+      it { should_not exist }
+    end
+
+    describe aws_iam_users.where(has_console_password?: true) do
+      it { should exist }
+    end
+  '
+
+  filter = FilterTable.create
+  filter.add_accessor(:where)
+        .add_accessor(:entries)
+        .add(:exists?) { |x| !x.entries.empty? }
+  filter.connect(self, :collect_user_details)
+
+  def initialize(aws_user_provider = AwsIam::UserProvider.new,
+                 user_factory = AwsIamUserFactory.new)
+    @user_provider = aws_user_provider
+    @user_factory = user_factory
+  end
+
+  def collect_user_details
+    @users_cache ||= @user_provider.list_users unless @user_provider.nil?
+  end
+
+  def users
+    users = []
+    users ||= @user_provider.list_users unless @user_provider.nil?
+    users.map { |user|
+      @user_factory.create_user(user)
+    }
+  end
+
+  def to_s
+    'IAM Users'
+  end
+
+  class AwsIamUserFactory
+    def create_user(user)
+      AwsIamUser.new(user: user)
+    end
+  end
+end

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = "~> 0.10.0"
+}
+
 provider "aws" {}
 
 resource "aws_instance" "example" {

--- a/test/integration/verify/controls/aws_ec2_instance.rb
+++ b/test/integration/verify/controls/aws_ec2_instance.rb
@@ -8,6 +8,18 @@ example_ec2_name = attribute(
   default: 'default.Example',
   description: 'Name of exapmle ec2 instance')
 
+describe aws_ec2_instance(name: example_ec2_name) do
+  it { should exist }
+  its('image_id') { should eq 'ami-0d729a60' }
+  its('instance_type') { should eq 't2.micro' }
+end
+
+describe aws_ec2_instance(example_ec2_id) do
+  it { should exist }
+  its('image_id') { should eq 'ami-0d729a60' }
+  its('instance_type') { should eq 't2.micro' }
+end
+
 describe aws_ec2(name: example_ec2_name) do
   it { should exist }
   its('image_id') { should eq 'ami-0d729a60' }
@@ -20,7 +32,7 @@ describe aws_ec2(example_ec2_id) do
   its('instance_type') { should eq 't2.micro' }
 end
 
-#must use a real EC2 instance name, as the SDK will first check to see if its well formed before sending requests
-describe aws_ec2('i-06b4bc106e0d03dfd') do
+# must use a real EC2 instance name, as the SDK will first check to see if its well formed before sending requests
+describe aws_ec2_instance('i-06b4bc106e0d03dfd') do
   it { should_not exist }
 end

--- a/test/integration/verify/controls/aws_iam_user.rb
+++ b/test/integration/verify/controls/aws_iam_user.rb
@@ -13,16 +13,16 @@ access_key_user = attribute(
   default: 'default.access_key_user',
   description: 'Name of IAM user access_key_user')
 
-describe aws_iam_user(mfa_not_enabled_user) do
+describe aws_iam_user(name: mfa_not_enabled_user) do
   it { should_not have_mfa_enabled }
   it { should_not have_console_password }
 end
 
-describe aws_iam_user(console_password_enabled_user) do
+describe aws_iam_user(name: console_password_enabled_user) do
   it { should have_console_password }
 end
 
-aws_iam_user(access_key_user).access_keys.each { |access_key|
+aws_iam_user(name: access_key_user).access_keys.each { |access_key|
   describe access_key do
    it { should be_active }
   end

--- a/test/integration/verify/controls/aws_iam_users.rb
+++ b/test/integration/verify/controls/aws_iam_users.rb
@@ -1,0 +1,3 @@
+describe aws_iam_users.where(has_console_password?: true).where(has_mfa_enabled?: false) do
+  it { should exist }
+end

--- a/test/unit/resources/aws_ec2_instance_test.rb
+++ b/test/unit/resources/aws_ec2_instance_test.rb
@@ -1,5 +1,5 @@
 require 'helper'
-require 'ec2'
+require 'aws_ec2_instance'
 
 class TestEc2 < Minitest::Test
   Id = 'instance-id'.freeze
@@ -14,7 +14,7 @@ class TestEc2 < Minitest::Test
   end
 
   def test_that_id_returns_id_directly_when_constructed_with_an_id
-    assert_equal Id, Ec2.new(Id, @mock_conn).id
+    assert_equal Id, AwsEc2Instance.new(Id, @mock_conn).id
   end
 
   def test_that_id_returns_fetched_id_when_constructed_with_a_name
@@ -22,32 +22,37 @@ class TestEc2 < Minitest::Test
     mock_instance.expect :nil?, false
     mock_instance.expect :id, Id
     @mock_resource.expect :instances, [mock_instance], [Hash]
-    assert_equal Id, Ec2.new({ name: 'cut' }, @mock_conn).id
+    assert_equal Id, AwsEc2Instance.new({ name: 'cut' }, @mock_conn).id
   end
 
   def test_that_instance_returns_instance_when_instance_exists
     mock_instance = Object.new
 
     @mock_resource.expect :instance, mock_instance, [Id]
-    assert_same mock_instance, Ec2.new(Id, @mock_conn).send(:instance)
+    assert_same mock_instance, AwsEc2Instance.new(
+      Id,
+      @mock_conn,
+    ).send(:instance)
   end
 
   def test_that_instance_returns_nil_when_instance_does_not_exist
     @mock_resource.expect :instance, nil, [Id]
-    assert Ec2.new(Id, @mock_conn).send(:instance).nil?
+    assert AwsEc2Instance.new(Id, @mock_conn).send(:instance).nil?
   end
 
   def test_that_exists_returns_true_when_instance_exists
     mock_instance = Minitest::Mock.new
+    mock_instance.expect :nil?, false
     mock_instance.expect :exists?, true
     @mock_resource.expect :instance, mock_instance, [Id]
-    assert Ec2.new(Id, @mock_conn).exists?
+    assert AwsEc2Instance.new(Id, @mock_conn).exists?
   end
 
   def test_that_exists_returns_false_when_instance_does_not_exist
     mock_instance = Minitest::Mock.new
+    mock_instance.expect :nil?, false
     mock_instance.expect :exists?, false
     @mock_resource.expect :instance, mock_instance, [Id]
-    assert !Ec2.new(Id, @mock_conn).exists?
+    assert !AwsEc2Instance.new(Id, @mock_conn).exists?
   end
 end

--- a/test/unit/resources/aws_iam_access_key_test.rb
+++ b/test/unit/resources/aws_iam_access_key_test.rb
@@ -6,9 +6,9 @@ require 'helper'
 require 'aws_iam_access_key'
 
 class AwsIamAccessKeyTest < Minitest::Test
-  Username = 'test' 
-  Id = 'id'
-  Date = 'date'
+  Username = 'test'.freeze
+  Id = 'id'.freeze
+  Date = 'date'.freeze
 
   module AccessKeyFactory
     def aws_iam_access_key(decorator = mock_decorator(stub_access_key))
@@ -16,17 +16,18 @@ class AwsIamAccessKeyTest < Minitest::Test
     end
 
     def stub_access_key(
-      _nil: false,
       id: Id,
       status: 'Active',
       create_date: Date
     )
-      OpenStruct.new({
-        :nil? => _nil,
-        :access_key_id => id,
-        :status => status,
-        :create_date => create_date
-      })
+      OpenStruct.new(
+        {
+          nil?: nil,
+          access_key_id: id,
+          status: status,
+          create_date: create_date,
+        },
+      )
     end
   end
 
@@ -35,27 +36,32 @@ class AwsIamAccessKeyTest < Minitest::Test
   def test_initialize_accepts_fields
     assert_equal(
       Id,
-      AwsIamAccessKey.new({id: Id, username: Username}, nil)
-        .instance_variable_get('@id')
-    );
+      AwsIamAccessKey.new({ id: Id, username: Username }, nil)
+        .instance_variable_get('@id'),
+    )
   end
 
   def test_initialize_accepts_access_key
     assert_equal(
       Id,
-      AwsIamAccessKey.new({access_key: OpenStruct.new(access_key_id: Id)}, nil)
-        .instance_variable_get('@id')
-    );
+      AwsIamAccessKey.new(
+        {
+          access_key: OpenStruct.new(access_key_id: Id),
+        }, nil
+      ).instance_variable_get('@id'),
+    )
   end
 
   def test_initialize_prefers_access_key
     assert_equal(
       Id,
-      AwsIamAccessKey.new({
-        id: 'foo',
-        access_key: OpenStruct.new(access_key_id: Id)
-      }, nil).instance_variable_get('@id')
-    );
+      AwsIamAccessKey.new(
+        {
+          id: 'foo',
+          access_key: OpenStruct.new(access_key_id: Id),
+        }, nil
+      ).instance_variable_get('@id'),
+    )
   end
 
   def test_exists_returns_true_when_access_key_exists
@@ -64,7 +70,8 @@ class AwsIamAccessKeyTest < Minitest::Test
 
   def test_exists_returns_false_when_sdk_raises
     mock_decorator = mock_decorator_raise(
-      Aws::IAM::Errors::NoSuchEntity.new(nil, nil))
+      Aws::IAM::Errors::NoSuchEntity.new(nil, nil),
+    )
 
     refute aws_iam_access_key(mock_decorator).exists?
 
@@ -73,7 +80,8 @@ class AwsIamAccessKeyTest < Minitest::Test
 
   def test_exists_returns_false_when_access_key_does_not_exist
     mock_decorator = mock_decorator_raise(
-      AwsIamAccessKey::AccessKeyNotFoundError.new)
+      AwsIamAccessKey::AccessKeyNotFoundError.new,
+    )
 
     refute aws_iam_access_key(mock_decorator).exists?
 
@@ -100,8 +108,12 @@ class AwsIamAccessKeyTest < Minitest::Test
   def test_last_used_date_returns_last_used_date_always
     assert_equal(
       Date,
-      aws_iam_access_key(mock_decorator(nil,
-        OpenStruct.new({ :last_used_date => Date }))).last_used_date
+      aws_iam_access_key(
+        mock_decorator(
+          nil,
+          OpenStruct.new({ last_used_date: Date }),
+        ),
+      ).last_used_date,
     )
   end
 
@@ -110,7 +122,7 @@ class AwsIamAccessKeyTest < Minitest::Test
 
     def test_get_access_key_raises_when_no_access_keys_found
       validator = mock_validator
-      
+
       e = assert_raises AwsIamAccessKey::AccessKeyNotFoundError do
         iam_client_decorator(validator).get_access_key(Username, Id)
       end
@@ -124,10 +136,12 @@ class AwsIamAccessKeyTest < Minitest::Test
 
     def test_get_access_key_raises_when_matching_access_key_not_found
       validator = mock_validator
-      
-      e = assert_raises AwsIamAccessKey::AccessKeyNotFoundError do 
-        iam_client_decorator(validator, [stub_access_key(id: 'Foo')])
-          .get_access_key(Username, Id)
+
+      e = assert_raises AwsIamAccessKey::AccessKeyNotFoundError do
+        iam_client_decorator(
+          validator,
+          [stub_access_key(id: 'Foo')],
+        ).get_access_key(Username, Id)
       end
 
       assert_match(/.*access key not found.*/, e.message)
@@ -143,7 +157,10 @@ class AwsIamAccessKeyTest < Minitest::Test
 
       assert_equal(
         access_key,
-        iam_client_decorator(validator, [access_key]).get_access_key(Username, Id)
+        iam_client_decorator(
+          validator,
+          [access_key],
+        ).get_access_key(Username, Id),
       )
 
       validator.verify
@@ -155,8 +172,11 @@ class AwsIamAccessKeyTest < Minitest::Test
 
       assert_equal(
         access_key_last_used,
-        iam_client_decorator(validator, nil, access_key_last_used)
-          .get_access_key_last_used(Id)
+        iam_client_decorator(
+          validator,
+          nil,
+          access_key_last_used,
+        ).get_access_key_last_used(Id),
       )
 
       validator.verify
@@ -165,9 +185,9 @@ class AwsIamAccessKeyTest < Minitest::Test
     class ArgumentValidatorTest < Minitest::Test
       def test_validate_id_raises_when_id_is_nil
         argument_validator.validate_id(nil)
-	flunk
+        flunk
       rescue ArgumentError => e
-	assert_match(/.*missing.*"id".*/, e.message)
+        assert_match(/.*missing.*"id".*/, e.message)
       end
 
       def test_validate_id_does_nothing_when_id_is_not_nil
@@ -175,18 +195,18 @@ class AwsIamAccessKeyTest < Minitest::Test
       end
 
       def test_validate_username_raises_when_username_is_nil
-	argument_validator.validate_username(nil)
-	flunk
+        argument_validator.validate_username(nil)
+        flunk
       rescue ArgumentError => e
-	assert_match(/.*missing.*"username".*/, e.message)
+        assert_match(/.*missing.*"username".*/, e.message)
       end
 
       def test_validate_username_does_nothing_when_username_is_not_nil
-        argument_validator.validate_username(Username) 
+        argument_validator.validate_username(Username)
       end
 
       def argument_validator
-	AwsIamAccessKey::IamClientDecorator::ArgumentValidator.new
+        AwsIamAccessKey::IamClientDecorator::ArgumentValidator.new
       end
     end
 
@@ -203,7 +223,7 @@ class AwsIamAccessKeyTest < Minitest::Test
     def mock_conn(access_keys, access_key_last_used = nil)
       Minitest::Mock.new.expect(
         :iam_client,
-        mock_client(access_keys, access_key_last_used)
+        mock_client(access_keys, access_key_last_used),
       )
     end
 
@@ -213,25 +233,30 @@ class AwsIamAccessKeyTest < Minitest::Test
       if access_keys
         mock_iam_client.expect(
           :list_access_keys,
-          OpenStruct.new({'access_key_metadata' => access_keys}),
-          [{user_name: Username}]
+          OpenStruct.new({ 'access_key_metadata' => access_keys }),
+          [{ user_name: Username }],
         )
       end
 
       if access_key_last_used
         mock_iam_client.expect(
           :get_access_key_last_used,
-          OpenStruct.new({'access_key_last_used' => access_key_last_used}),
-          [{access_key_id: Id}]
+          OpenStruct.new({ 'access_key_last_used' => access_key_last_used }),
+          [{ access_key_id: Id }],
         )
       end
 
       mock_iam_client
     end
 
-    def iam_client_decorator(validator, access_keys = [], access_key_last_used = nil)
+    def iam_client_decorator(
+      validator,
+      access_keys = [],
+      access_key_last_used = nil
+    )
       AwsIamAccessKey::IamClientDecorator.new(
-        validator, mock_conn(access_keys, access_key_last_used))
+        validator, mock_conn(access_keys, access_key_last_used)
+      )
     end
   end
 
@@ -243,7 +268,11 @@ class AwsIamAccessKeyTest < Minitest::Test
     end
 
     if access_key_last_used
-      mock_decorator.expect :get_access_key_last_used, access_key_last_used, [Id]
+      mock_decorator.expect(
+        :get_access_key_last_used,
+        access_key_last_used,
+        [Id],
+      )
     end
 
     mock_decorator
@@ -252,7 +281,7 @@ class AwsIamAccessKeyTest < Minitest::Test
   def mock_decorator_raise(error)
     Minitest::Mock.new.expect(:get_access_key, nil) do |username, id|
       assert_equal Username, username
-      assert_equal Id, id  
+      assert_equal Id, id
 
       raise error
     end

--- a/test/unit/resources/aws_iam_password_policy_test.rb
+++ b/test/unit/resources/aws_iam_password_policy_test.rb
@@ -5,33 +5,33 @@ require 'json'
 
 class AwsIamPasswordPolicyTest < Minitest::Test
   def setup
-    @mockConn = Minitest::Mock.new
-    @mockResource = Minitest::Mock.new
-    @mockPolicy = Minitest::Mock.new
+    @mock_conn = Minitest::Mock.new
+    @mock_resource = Minitest::Mock.new
+    @mock_policy = Minitest::Mock.new
 
-    @mockConn.expect :iam_resource, @mockResource
+    @mock_conn.expect :iam_resource, @mock_resource
   end
 
   def test_policy_exists_when_policy_exists
-    @mockResource.expect :account_password_policy, true
+    @mock_resource.expect :account_password_policy, true
 
-    assert_equal true, AwsIamPasswordPolicy.new(@mockConn).exists?
+    assert_equal true, AwsIamPasswordPolicy.new(@mock_conn).exists?
   end
 
   def test_policy_does_not_exists_when_no_policy
-    @mockResource.expect :account_password_policy, nil do |args|
+    @mock_resource.expect :account_password_policy, nil do
       raise Aws::IAM::Errors::NoSuchEntity.new nil, nil
     end
 
-    assert_equal false, AwsIamPasswordPolicy.new(@mockConn).exists?
+    assert_equal false, AwsIamPasswordPolicy.new(@mock_conn).exists?
   end
 
   def test_throws_when_password_age_0
-    @mockPolicy.expect :expire_passwords, false
-    @mockResource.expect :account_password_policy, @mockPolicy
+    @mock_policy.expect :expire_passwords, false
+    @mock_resource.expect :account_password_policy, @mock_policy
 
     e = assert_raises Exception do
-      AwsIamPasswordPolicy.new(@mockConn).max_password_age
+      AwsIamPasswordPolicy.new(@mock_conn).max_password_age
     end
 
     assert_equal e.message, 'this policy does not expire passwords'
@@ -40,43 +40,46 @@ class AwsIamPasswordPolicyTest < Minitest::Test
   def test_prevents_password_reuse_returns_true_when_not_nil
     configure_policy_password_reuse_prevention(value: Object.new)
 
-    assert AwsIamPasswordPolicy.new(@mockConn).prevents_password_reuse?
+    assert AwsIamPasswordPolicy.new(@mock_conn).prevents_password_reuse?
   end
 
   def test_prevents_password_reuse_returns_false_when_nil
     configure_policy_password_reuse_prevention(value: nil)
 
-    refute AwsIamPasswordPolicy.new(@mockConn).prevents_password_reuse?
+    refute AwsIamPasswordPolicy.new(@mock_conn).prevents_password_reuse?
   end
 
   def test_number_of_passwords_to_remember_throws_when_nil
     configure_policy_password_reuse_prevention(value: nil)
 
     e = assert_raises Exception do
-      AwsIamPasswordPolicy.new(@mockConn).number_of_passwords_to_remember
+      AwsIamPasswordPolicy.new(@mock_conn).number_of_passwords_to_remember
     end
 
     assert_equal e.message, 'this policy does not prevent password reuse'
   end
 
   def test_number_of_passwords_to_remember_returns_configured_value
-    expectedValue = 5
-    configure_policy_password_reuse_prevention(value: expectedValue, n: 2)
+    expected_value = 5
+    configure_policy_password_reuse_prevention(value: expected_value, n: 2)
 
-    assert_equal expectedValue, AwsIamPasswordPolicy.new(@mockConn).number_of_passwords_to_remember
+    assert_equal(
+      expected_value,
+      AwsIamPasswordPolicy.new(@mock_conn).number_of_passwords_to_remember,
+    )
   end
 
   def test_policy_to_s
     configure_policy_password_reuse_prevention(value: Object.new)
-    expectedValue = "IAM Password-Policy"
-    test = AwsIamPasswordPolicy.new(@mockConn).to_s
-    assert_equal expectedValue, test
+    expected_value = 'IAM Password-Policy'
+    test = AwsIamPasswordPolicy.new(@mock_conn).to_s
+    assert_equal expected_value, test
   end
 
-  private 
+  private
 
-  def configure_policy_password_reuse_prevention(value: value, n: 1)
-    n.times { @mockPolicy.expect :password_reuse_prevention, value }
-    @mockResource.expect :account_password_policy, @mockPolicy
+  def configure_policy_password_reuse_prevention(value: value=nil, n: 1)
+    n.times { @mock_policy.expect :password_reuse_prevention, value }
+    @mock_resource.expect :account_password_policy, @mock_policy
   end
 end

--- a/test/unit/resources/aws_iam_password_policy_test.rb
+++ b/test/unit/resources/aws_iam_password_policy_test.rb
@@ -66,6 +66,13 @@ class AwsIamPasswordPolicyTest < Minitest::Test
     assert_equal expectedValue, AwsIamPasswordPolicy.new(@mockConn).number_of_passwords_to_remember
   end
 
+  def test_policy_to_s
+    configure_policy_password_reuse_prevention(value: Object.new)
+    expectedValue = "IAM Password-Policy"
+    test = AwsIamPasswordPolicy.new(@mockConn).to_s
+    assert_equal expectedValue, test
+  end
+
   private 
 
   def configure_policy_password_reuse_prevention(value: value, n: 1)

--- a/test/unit/resources/aws_iam_root_user_test.rb
+++ b/test/unit/resources/aws_iam_root_user_test.rb
@@ -4,17 +4,19 @@ require 'aws_iam_root_user'
 
 class AwsIamRootUserTest < Minitest::Test
   def setup
-    @mockConn = Minitest::Mock.new
-    @mockClient = Minitest::Mock.new
+    @mock_conn = Minitest::Mock.new
+    @mock_client = Minitest::Mock.new
 
-    @mockConn.expect :iam_client, @mockClient
+    @mock_conn.expect :iam_client, @mock_client
   end
 
   def test_access_key_count_returns_from_summary_account
-    expectedKeys = 2
-    summaryMap = OpenStruct.new(summary_map: {'AccountAccessKeysPresent' => expectedKeys})
-    @mockClient.expect :get_account_summary, summaryMap
+    expected_keys = 2
+    test_summary_map = OpenStruct.new(
+      summary_map: { 'AccountAccessKeysPresent' => expected_keys },
+    )
+    @mock_client.expect :get_account_summary, test_summary_map
 
-    assert_equal expectedKeys, AwsIamRootUser.new(@mockConn).access_key_count
+    assert_equal expected_keys, AwsIamRootUser.new(@mock_conn).access_key_count
   end
 end

--- a/test/unit/resources/aws_iam_root_user_test.rb
+++ b/test/unit/resources/aws_iam_root_user_test.rb
@@ -19,4 +19,22 @@ class AwsIamRootUserTest < Minitest::Test
 
     assert_equal expected_keys, AwsIamRootUser.new(@mock_conn).access_key_count
   end
+
+  def test_has_mfa_enabled_returns_true_when_account_mfa_devices_is_one
+    test_summary_map = OpenStruct.new(
+      summary_map: { 'AccountMFAEnabled' => 1 },
+    )
+    @mock_client.expect :get_account_summary, test_summary_map
+
+    assert_equal true, AwsIamRootUser.new(@mock_conn).has_mfa_enabled?
+  end
+
+  def test_has_mfa_enabled_returns_false_when_account_mfa_devices_is_zero
+    test_summary_map = OpenStruct.new(
+      summary_map: { 'AccountMFAEnabled' => 0 },
+    )
+    @mock_client.expect :get_account_summary, test_summary_map
+
+    assert_equal false, AwsIamRootUser.new(@mock_conn).has_mfa_enabled?
+  end
 end

--- a/test/unit/resources/aws_iam_user_provider_test.rb
+++ b/test/unit/resources/aws_iam_user_provider_test.rb
@@ -24,15 +24,15 @@ class AwsIamUserProviderTest < Minitest::Test
   def test_list_users
     @mock_iam_resource.expect(
       :users,
-      [create_mock_user, create_mock_user, create_mock_user],
+      [create_mock_user, create_mock_user],
     )
     mock_user_output = {
+      name: Username,
       has_mfa_enabled?: true,
       has_console_password?: true,
       access_keys: [],
     }
-    assert @user_provider.list_users == [mock_user_output, mock_user_output,
-                                         mock_user_output]
+    assert @user_provider.list_users == [mock_user_output, mock_user_output]
   end
 
   def test_list_users_no_users
@@ -107,6 +107,7 @@ class AwsIamUserProviderTest < Minitest::Test
     mock_login_profile.expect :create_date, has_console_password ? 'date' : nil
 
     mock_user = Minitest::Mock.new
+    mock_user.expect :name, Username
     mock_user.expect :mfa_devices, has_mfa_enabled ? ['device'] : []
     mock_user.expect :login_profile, mock_login_profile
     mock_user.expect :access_keys, access_keys
@@ -119,6 +120,7 @@ class AwsIamUserProviderTest < Minitest::Test
     end
 
     mock_user = Minitest::Mock.new
+    mock_user.expect :name, Username
     mock_user.expect :mfa_devices, []
     mock_user.expect :login_profile, mock_login_profile
     mock_user.expect :access_keys, []

--- a/test/unit/resources/aws_iam_user_provider_test.rb
+++ b/test/unit/resources/aws_iam_user_provider_test.rb
@@ -4,11 +4,10 @@
 # author: Alex Bedley
 require 'aws-sdk'
 require 'helper'
-
 require 'aws_iam_user_provider'
 
 class AwsIamUserProviderTest < Minitest::Test
-  Username = "test"
+  Username = 'test'.freeze
 
   def setup
     @mock_iam_resource = Minitest::Mock.new
@@ -23,9 +22,17 @@ class AwsIamUserProviderTest < Minitest::Test
   end
 
   def test_list_users
-    @mock_iam_resource.expect :users, [create_mock_user, create_mock_user, create_mock_user]
-    mock_user_output = {has_mfa_enabled?: true, has_console_password?: true, access_keys: []}
-    assert @user_provider.list_users == [mock_user_output, mock_user_output, mock_user_output]
+    @mock_iam_resource.expect(
+      :users,
+      [create_mock_user, create_mock_user, create_mock_user],
+    )
+    mock_user_output = {
+      has_mfa_enabled?: true,
+      has_console_password?: true,
+      access_keys: [],
+    }
+    assert @user_provider.list_users == [mock_user_output, mock_user_output,
+                                         mock_user_output]
   end
 
   def test_list_users_no_users
@@ -34,34 +41,48 @@ class AwsIamUserProviderTest < Minitest::Test
   end
 
   def test_has_mfa_enabled_returns_true
-    @mock_iam_resource.expect :user, create_mock_user(has_mfa_enabled: true), [Username]
+    @mock_iam_resource.expect(:user, create_mock_user(has_mfa_enabled: true),
+                              [Username])
     assert @user_provider.user(Username)[:has_mfa_enabled?]
   end
 
   def test_has_mfa_enabled_returns_false
-    @mock_iam_resource.expect :user, create_mock_user(has_mfa_enabled: false), [Username]
+    @mock_iam_resource.expect(:user, create_mock_user(has_mfa_enabled: false),
+                              [Username])
     assert !@user_provider.user(Username)[:has_mfa_enabled?]
   end
-  
+
   def test_has_console_password_returns_true
-    @mock_iam_resource.expect :user, create_mock_user(has_console_password: true), [Username]
+    @mock_iam_resource.expect(
+      :user,
+      create_mock_user(has_console_password: true),
+      [Username],
+    )
     assert @user_provider.user(Username)[:has_console_password?]
   end
 
   def test_has_console_password_returns_false
-    @mock_iam_resource.expect :user, create_mock_user(has_console_password: false), [Username]
+    @mock_iam_resource.expect(
+      :user,
+      create_mock_user(has_console_password: false),
+      [Username],
+    )
     assert !@user_provider.user(Username)[:has_console_password?]
   end
-  
+
   def test_has_console_password_returns_false_when_nosuchentity
-    @mock_iam_resource.expect :user, create_mock_user_throw(Aws::IAM::Errors::NoSuchEntity.new(nil, nil)), [Username]
-    
+    @mock_iam_resource.expect(
+      :user,
+      create_mock_user_throw(Aws::IAM::Errors::NoSuchEntity.new(nil, nil)),
+      [Username],
+    )
     assert !@user_provider.user(Username)[:has_console_password?]
   end
-  
+
   def test_has_console_password_throws
-    @mock_iam_resource.expect :user, create_mock_user_throw(ArgumentError), [Username]
-    
+    @mock_iam_resource.expect(:user, create_mock_user_throw(ArgumentError),
+                              [Username])
+
     assert_raises ArgumentError do
       @user_provider.user(Username)
     end
@@ -69,30 +90,34 @@ class AwsIamUserProviderTest < Minitest::Test
 
   def test_access_keys_returns_access_keys
     access_key = Object.new
-
-    @mock_iam_resource.expect :user, create_mock_user(access_keys: [access_key]), [Username]
+    @mock_iam_resource.expect(
+      :user,
+      create_mock_user(access_keys: [access_key]),
+      [Username],
+    )
 
     assert_equal [access_key], @user_provider.user(Username)[:access_keys]
   end
 
   private
 
-  def create_mock_user(has_console_password: true, has_mfa_enabled: true, access_keys: [])
+  def create_mock_user(has_console_password: true, has_mfa_enabled: true,
+                       access_keys: [])
     mock_login_profile = Minitest::Mock.new
     mock_login_profile.expect :create_date, has_console_password ? 'date' : nil
-    
+
     mock_user = Minitest::Mock.new
     mock_user.expect :mfa_devices, has_mfa_enabled ? ['device'] : []
     mock_user.expect :login_profile, mock_login_profile
     mock_user.expect :access_keys, access_keys
   end
-  
+
   def create_mock_user_throw(exception)
     mock_login_profile = Minitest::Mock.new
-    mock_login_profile.expect :create_date, nil do |args|
+    mock_login_profile.expect :create_date, nil do
       raise exception
     end
-    
+
     mock_user = Minitest::Mock.new
     mock_user.expect :mfa_devices, []
     mock_user.expect :login_profile, mock_login_profile

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -44,4 +44,11 @@ class AwsIamUserTest < Minitest::Test
 
     mock_access_key_factory.verify
   end
+
+  def test_to_s
+    @mock_user_provider.expect :user, {has_mfa_enabled?: true}, [Username]
+    expected = "IAM User test"
+    test = AwsIamUser.new(Username, @mock_user_provider).to_s
+    assert_equal expected, test
+  end
 end

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -16,7 +16,12 @@ class AwsIamUserTest < Minitest::Test
       { has_mfa_enabled?: true },
       [Username],
     )
-    assert AwsIamUser.new(Username, @mock_user_provider).has_mfa_enabled?
+    assert(
+      AwsIamUser.new(
+        { name: Username },
+        @mock_user_provider,
+      ).has_mfa_enabled?,
+    )
   end
 
   def test_mfa_enabled_returns_false_if_mfa_is_not_enabled
@@ -25,7 +30,12 @@ class AwsIamUserTest < Minitest::Test
       { has_mfa_enabled?: false },
       [Username],
     )
-    refute AwsIamUser.new(Username, @mock_user_provider).has_mfa_enabled?
+    refute(
+      AwsIamUser.new(
+        { name: Username },
+        @mock_user_provider,
+      ).has_mfa_enabled?,
+    )
   end
 
   def test_console_password_returns_true_if_console_password_has_been_set
@@ -34,7 +44,12 @@ class AwsIamUserTest < Minitest::Test
       { has_console_password?: true },
       [Username],
     )
-    assert AwsIamUser.new(Username, @mock_user_provider).has_console_password?
+    assert(
+      AwsIamUser.new(
+        { name: Username },
+        @mock_user_provider,
+      ).has_console_password?,
+    )
   end
 
   def test_console_password_returns_false_if_console_password_has_not_been_set
@@ -43,7 +58,12 @@ class AwsIamUserTest < Minitest::Test
       { has_console_password?: false },
       [Username],
     )
-    refute AwsIamUser.new(Username, @mock_user_provider).has_console_password?
+    refute(
+      AwsIamUser.new(
+        { name: Username },
+        @mock_user_provider,
+      ).has_console_password?,
+    )
   end
 
   def test_that_access_keys_returns_aws_iam_access_key_resources
@@ -65,7 +85,7 @@ class AwsIamUserTest < Minitest::Test
     assert_equal(
       stub_access_key_resource,
       AwsIamUser.new(
-        Username,
+        { name: Username },
         @mock_user_provider,
         mock_access_key_factory,
       ).access_keys[0],
@@ -75,9 +95,13 @@ class AwsIamUserTest < Minitest::Test
   end
 
   def test_to_s
-    @mock_user_provider.expect :user, { has_mfa_enabled?: true }, [Username]
-    expected = 'IAM User test'
-    test = AwsIamUser.new(Username, @mock_user_provider).to_s
+    @mock_user_provider.expect(
+      :user,
+      { name: Username, has_mfa_enabled?: true },
+      [Username],
+    )
+    expected = "IAM User #{Username}"
+    test = AwsIamUser.new({ name: Username }, @mock_user_provider).to_s
     assert_equal expected, test
   end
 end

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -1,33 +1,48 @@
 # author: Simon Varlow
 require 'aws-sdk'
 require 'helper'
-
 require 'aws_iam_user'
 
 class AwsIamUserTest < Minitest::Test
-  Username = "test" 
-  
+  Username = 'test'.freeze
+
   def setup
     @mock_user_provider = Minitest::Mock.new
   end
 
-  def test_that_MFA_enable_returns_true_if_MFA_Enabled
-    @mock_user_provider.expect :user, {has_mfa_enabled?: true}, [Username]
+  def test_mfa_enabled_returns_true_if_mfa_enabled
+    @mock_user_provider.expect(
+      :user,
+      { has_mfa_enabled?: true },
+      [Username],
+    )
     assert AwsIamUser.new(Username, @mock_user_provider).has_mfa_enabled?
   end
 
-  def test_that_MFA_enable_returns_false_if_MFA_is_not_Enabled
-    @mock_user_provider.expect :user, {has_mfa_enabled?: false}, [Username]
+  def test_mfa_enabled_returns_false_if_mfa_is_not_enabled
+    @mock_user_provider.expect(
+      :user,
+      { has_mfa_enabled?: false },
+      [Username],
+    )
     refute AwsIamUser.new(Username, @mock_user_provider).has_mfa_enabled?
   end
 
-  def test_that_console_Password_returns_true_if_console_Password_has_been_set
-    @mock_user_provider.expect :user, {has_console_password?: true}, [Username]
+  def test_console_password_returns_true_if_console_password_has_been_set
+    @mock_user_provider.expect(
+      :user,
+      { has_console_password?: true },
+      [Username],
+    )
     assert AwsIamUser.new(Username, @mock_user_provider).has_console_password?
   end
 
-  def test_that_console_Password_returns_false_if_console_Password_has_not_been_set
-    @mock_user_provider.expect :user, {has_console_password?: false}, [Username]
+  def test_console_password_returns_false_if_console_password_has_not_been_set
+    @mock_user_provider.expect(
+      :user,
+      { has_console_password?: false },
+      [Username],
+    )
     refute AwsIamUser.new(Username, @mock_user_provider).has_console_password?
   end
 
@@ -36,18 +51,32 @@ class AwsIamUserTest < Minitest::Test
     stub_access_key_resource = Object.new
     mock_access_key_factory = Minitest::Mock.new
 
-    @mock_user_provider.expect :user, {access_keys: [stub_aws_access_key]}, [Username]
-    mock_access_key_factory.expect :create_access_key, stub_access_key_resource, [stub_aws_access_key]
+    @mock_user_provider.expect(
+      :user,
+      { access_keys: [stub_aws_access_key] },
+      [Username],
+    )
+    mock_access_key_factory.expect(
+      :create_access_key,
+      stub_access_key_resource,
+      [stub_aws_access_key],
+    )
 
-    assert_equal(stub_access_key_resource,
-                 AwsIamUser.new(Username, @mock_user_provider, mock_access_key_factory).access_keys[0])
+    assert_equal(
+      stub_access_key_resource,
+      AwsIamUser.new(
+        Username,
+        @mock_user_provider,
+        mock_access_key_factory,
+      ).access_keys[0],
+    )
 
     mock_access_key_factory.verify
   end
 
   def test_to_s
-    @mock_user_provider.expect :user, {has_mfa_enabled?: true}, [Username]
-    expected = "IAM User test"
+    @mock_user_provider.expect :user, { has_mfa_enabled?: true }, [Username]
+    expected = 'IAM User test'
     test = AwsIamUser.new(Username, @mock_user_provider).to_s
     assert_equal expected, test
   end

--- a/test/unit/resources/aws_iam_users_test.rb
+++ b/test/unit/resources/aws_iam_users_test.rb
@@ -1,0 +1,81 @@
+# author: Adnan Duric
+# author: Steffanie Freeman
+# author: Simon Varlow
+# author: Chris Redekop
+require 'aws-sdk'
+require 'helper'
+require 'aws_iam_users'
+
+class AwsIamUsersTest < Minitest::Test
+  def setup
+    @mock_user_factory = Minitest::Mock.new
+  end
+
+  def test_users_nil_user_provider_returns_empty_list
+    cut = AwsIamUsers.new(nil, @mock_user_factory)
+
+    assert_equal(cut.users, [])
+  end
+
+  def test_users_empty_list_user_provider_returns_empty_list
+    cut = AwsIamUsers.new(create_mock_user_provider, @mock_user_factory)
+
+    assert_equal(cut.users, [])
+  end
+
+  def test_users_returns_true_for_all_users_if_mfa_enabled
+    cut = AwsIamUsers.new(
+      create_mock_user_provider(create_mock_users([true, true])),
+      @mock_user_factory,
+    )
+
+    cut.users.each do |user|
+      assert user.has_mfa_enabled?
+    end
+  end
+
+  [
+    {
+      name: 'test_where_returns_no_matching_rows',
+      user_material: [false],
+    }, {
+      name: 'test_where_returns_some_matching_rows',
+      user_material: [true, false],
+    }, {
+      name: 'test_where_returns_all_matching_rows',
+      user_material: [true],
+    }
+  ].each do |test_material|
+    define_method(test_material[:name]) do
+      cut = AwsIamUsers.new(
+        create_mock_user_provider(
+          create_mock_users(test_material[:user_material]),
+        ),
+        @mock_user_factory,
+      )
+
+      results = cut.where(has_mfa_enabled?: true)
+      expected_count = test_material[:user_material].count { |x| x }
+
+      assert_equal expected_count > 0, results.exists?
+      assert_equal expected_count, results.entries.length
+    end
+  end
+
+  def create_mock_user_provider(user_list = [])
+    mock_user_provider = Minitest::Mock.new
+
+    mock_user_provider.expect :list_users, user_list
+    mock_user_provider.expect :nil?, false
+
+    mock_user_provider
+  end
+
+  def create_mock_users(has_mfa_enableds = [])
+    has_mfa_enableds.map { |x| create_mock_user(x) }
+  end
+
+  def create_mock_user(has_mfa_enabled = true)
+    { has_mfa_enabled?: has_mfa_enabled }
+  end
+end

--- a/test/unit/resources/ec2_test.rb
+++ b/test/unit/resources/ec2_test.rb
@@ -1,60 +1,53 @@
 require 'helper'
-
 require 'ec2'
 
 class TestEc2 < Minitest::Test
-  Id = "instance-id"
+  Id = 'instance-id'.freeze
 
   def setup
-    @mockConn = Minitest::Mock.new
-    @mockClient = Minitest::Mock.new
-    @mockResource = Minitest::Mock.new
+    @mock_conn = Minitest::Mock.new
+    @mock_client = Minitest::Mock.new
+    @mock_resource = Minitest::Mock.new
 
-    @mockConn.expect :ec2_client, @mockClient
-    @mockConn.expect :ec2_resource, @mockResource
+    @mock_conn.expect :ec2_client, @mock_client
+    @mock_conn.expect :ec2_resource, @mock_resource
   end
 
   def test_that_id_returns_id_directly_when_constructed_with_an_id
-    assert_equal Id, Ec2.new(Id, @mockConn).id
+    assert_equal Id, Ec2.new(Id, @mock_conn).id
   end
 
   def test_that_id_returns_fetched_id_when_constructed_with_a_name
-    mockInstance = Minitest::Mock.new
-
-    mockInstance.expect :nil?, false
-    mockInstance.expect :id, Id
-    @mockResource.expect :instances, [mockInstance], [Hash]
-     
-    assert_equal Id, Ec2.new({name: 'cut'}, @mockConn).id
+    mock_instance = Minitest::Mock.new
+    mock_instance.expect :nil?, false
+    mock_instance.expect :id, Id
+    @mock_resource.expect :instances, [mock_instance], [Hash]
+    assert_equal Id, Ec2.new({ name: 'cut' }, @mock_conn).id
   end
 
   def test_that_instance_returns_instance_when_instance_exists
-    mockInstance = Object.new
+    mock_instance = Object.new
 
-    @mockResource.expect :instance, mockInstance, [Id] 
-
-    assert_same mockInstance, Ec2.new(Id, @mockConn).send(:instance)
+    @mock_resource.expect :instance, mock_instance, [Id]
+    assert_same mock_instance, Ec2.new(Id, @mock_conn).send(:instance)
   end
 
   def test_that_instance_returns_nil_when_instance_does_not_exist
-    @mockResource.expect :instance, nil, [Id] 
-
-    assert Ec2.new(Id, @mockConn).send(:instance).nil?
+    @mock_resource.expect :instance, nil, [Id]
+    assert Ec2.new(Id, @mock_conn).send(:instance).nil?
   end
 
   def test_that_exists_returns_true_when_instance_exists
-    mockInstance = Minitest::Mock.new
-    mockInstance.expect :exists?, true
-    @mockResource.expect :instance, mockInstance, [Id] 
-
-    assert Ec2.new(Id, @mockConn).exists?
+    mock_instance = Minitest::Mock.new
+    mock_instance.expect :exists?, true
+    @mock_resource.expect :instance, mock_instance, [Id]
+    assert Ec2.new(Id, @mock_conn).exists?
   end
 
   def test_that_exists_returns_false_when_instance_does_not_exist
-    mockInstance = Minitest::Mock.new
-    mockInstance.expect :exists?, false
-    @mockResource.expect :instance, mockInstance, [Id]
-
-    assert !Ec2.new(Id, @mockConn).exists?
+    mock_instance = Minitest::Mock.new
+    mock_instance.expect :exists?, false
+    @mock_resource.expect :instance, mock_instance, [Id]
+    assert !Ec2.new(Id, @mock_conn).exists?
   end
 end


### PR DESCRIPTION
the control should describe an `aws_ec2` resource, not an `ec2` resource.

Signed-off-by: Nathen Harvey <nharvey@chef.io>
