### PR TITLE
Add has_mfa_enabled? to aws_iam_root_account

### DIFF
--- a/libraries/aws_iam_root_user.rb
+++ b/libraries/aws_iam_root_user.rb
@@ -16,6 +16,10 @@ class AwsIamRootUser < Inspec.resource(1)
     summary_account['AccountAccessKeysPresent']
   end
 
+  def has_mfa_enabled?
+    summary_account['AccountMFAEnabled'] == 1
+  end
+
   def to_s
     'AWS Root-User'
   end

--- a/test/unit/resources/aws_iam_root_user_test.rb
+++ b/test/unit/resources/aws_iam_root_user_test.rb
@@ -19,4 +19,22 @@ class AwsIamRootUserTest < Minitest::Test
 
     assert_equal expected_keys, AwsIamRootUser.new(@mock_conn).access_key_count
   end
+
+  def test_has_mfa_enabled_returns_true_when_account_mfa_devices_is_one
+    test_summary_map = OpenStruct.new(
+      summary_map: { 'AccountMFAEnabled' => 1 },
+    )
+    @mock_client.expect :get_account_summary, test_summary_map
+
+    assert_equal true, AwsIamRootUser.new(@mock_conn).has_mfa_enabled?
+  end
+
+  def test_has_mfa_enabled_returns_false_when_account_mfa_devices_is_zero
+    test_summary_map = OpenStruct.new(
+      summary_map: { 'AccountMFAEnabled' => 0 },
+    )
+    @mock_client.expect :get_account_summary, test_summary_map
+
+    assert_equal false, AwsIamRootUser.new(@mock_conn).has_mfa_enabled?
+  end
 end


### PR DESCRIPTION
Signed-off-by: Chris Redekop <chris.redekop@d2l.com>

@Rugbyte and I added the new method according to the AWS docs and the CIS benchmark.  Unit tests are included.  We do not have access to a hardware MFA device, so we cannot test this further.