### PR TITLE
README code examples are copy-paste-able.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ control "aws-1" do
   impact 0.7
   title 'Checks the machine is running'
 
-  describe ec2('my-ec2-machine') do
+  describe aws_ec2('i-my-ec2-instance-id') do
     it { should be_running }
   end
 end


### PR DESCRIPTION
The resource is `aws_ec2`, not `ec2`

Instance IDs must be passed to the `aws_ec2` resource, not machine names

Signed-off-by: Nathen Harvey <nharvey@chef.io>