### PR TITLE
Update Terraform commands for v0.10

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,6 +42,7 @@ namespace :test do
 
   task :configure_test_environment, :namespace do |t, args|
     puts "----> Creating terraform environment"
+    sh("cd #{integration_dir}/build/ && terraform init")
     sh("cd #{integration_dir}/build/ && terraform env new #{args[:namespace]}")
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,7 @@ namespace :test do
   task :configure_test_environment, :namespace do |t, args|
     puts "----> Creating terraform environment"
     sh("cd #{integration_dir}/build/ && terraform init")
-    sh("cd #{integration_dir}/build/ && terraform env new #{args[:namespace]}")
+    sh("cd #{integration_dir}/build/ && terraform workspace new #{args[:namespace]}")
   end
 
   task :setup_integration_tests do
@@ -70,8 +70,8 @@ namespace :test do
 
   task :destroy_test_environment, :namespace do |t, args|
     puts "----> Destroying terraform environment"
-    sh("cd #{integration_dir}/build/ && terraform env select default")
-    sh("cd #{integration_dir}/build && terraform env delete #{args[:namespace]}")
+    sh("cd #{integration_dir}/build/ && terraform workspace select default")
+    sh("cd #{integration_dir}/build && terraform workspace delete #{args[:namespace]}")
   end
 
   task :integration do

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = "~> 0.10.0"
+}
+
 provider "aws" {}
 
 resource "aws_instance" "example" {


### PR DESCRIPTION
Terraform, which is used in integration testing, changed several subcommands in the current v0.10 series.  This PR:

* Adds a call to `terraform init`, which is required to use the AWS provider
* Replaces calls to `terraform env` with `terraform workspace` to suppress a warning
* Adds a version pin so that we know we are using a compatible version of Terraform