### PR TITLE
Add documentation for existing resources

### DIFF
--- a/docs/resources/aws_ec2_instance.md
+++ b/docs/resources/aws_ec2_instance.md
@@ -68,7 +68,7 @@ The `be_running` matcher tests if the described EC2 instance state is `running`
 
     it { should be_running }
 
-### be_shutting_down_
+### be_shutting_down
 
 The `be_shutting_down` matcher tests if the described EC2 instance state is `shutting-down`
 

--- a/docs/resources/aws_ec2_instance.md
+++ b/docs/resources/aws_ec2_instance.md
@@ -54,4 +54,46 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers (such as `be_running`) please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of available matchers (such as `exist`) please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### be_pending
+
+The `pending` matcher tests if the described EC2 instance state is `pending`
+
+    it { should be_pending }
+
+### be_running
+
+The `be_running` matcher tests if the described EC2 instance state is `running`
+
+    it { should be_running }
+
+### be_shutting_down_
+
+The `be_shutting_down` matcher tests if the described EC2 instance state is `shutting-down`
+
+    it { should be_shutting_down }
+
+### be_stopped
+
+The `be_stopped` matcher tests if the described EC2 instance state is `stopped`
+
+    it { should be_stopped }
+
+### be_stopping
+
+The `be_stopping` matcher tests if the described EC2 instance state is `stopping`
+
+    it { should be_stopping }
+
+### be_terminated
+
+The `be_terminated` matcher tests if the described EC2 instance state is `terminated`
+
+    it { should be_terminated }
+
+### be_unknown
+
+The `be_unknown` matcher tests if the described EC2 instance state is `unknown`
+
+    it { should be_unknown }

--- a/docs/resources/aws_ec2_instance.md
+++ b/docs/resources/aws_ec2_instance.md
@@ -1,0 +1,57 @@
+---
+title: About the aws_ec2_instance Resource
+---
+
+# aws_ec2_instance
+
+Use the `aws_ec2_instance` InSpec audit resource to test properties of a single AWS EC2 instance.
+
+<br>
+
+## Syntax
+
+An `aws_ec2_instance` resource block declares a tests for a single AWS EC2 instance by name or id.
+
+    describe aws_ec2_instance('i-01a2349e94458a507') do
+      it { should exist }
+    end
+
+    describe aws_ec2_instance(name: 'my-instance') do
+      it { should be_running }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that an EC2 instance does not exist
+
+    describe aws_ec2_instance(name: 'dev-server') do
+      it { should_not exist }
+    end
+
+### Test that an EC2 instance is running
+
+    describe aws_ec2_instance(name: 'prod-database') do
+      it { should be_running }
+    end
+
+### Test that an EC2 instance is using the correct image ID
+
+    describe aws_iam_user(name: 'my-instance') do
+      its('image_id') { should eq 'ami-27a58d5c' }
+    end
+
+### Test that an EC2 instance has the correct tag
+
+    describe aws_ec2_instance('i-090c29e4f4c165b74') do
+      its('tags') { should include(key: 'Contact', value: 'Gilfoyle') }
+    end
+
+<br>
+
+## Matchers
+
+For a full list of available matchers (such as `be_running`) please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/docs/resources/aws_ec2_instance.md
+++ b/docs/resources/aws_ec2_instance.md
@@ -58,7 +58,7 @@ This InSpec audit resource has the following special matchers. For a full list o
 
 ### be_pending
 
-The `pending` matcher tests if the described EC2 instance state is `pending`
+The `be_pending` matcher tests if the described EC2 instance state is `pending`
 
     it { should be_pending }
 

--- a/docs/resources/aws_iam_access_key.md
+++ b/docs/resources/aws_iam_access_key.md
@@ -1,0 +1,50 @@
+---
+title: About the aws_iam_access_key Resource
+---
+
+# aws_iam_access_key
+
+Use the `aws_iam_access_key` InSpec audit resource to test properties of a single AWS IAM access key.
+
+<br>
+
+## Syntax
+
+An `aws_iam_access_key` resource block declares a tests for a single AWS IAM access key by username and id.
+
+    describe aws_iam_access_key(username: 'username', id: 'access-key-id') do
+      it { should exist }
+      it { should_not be_active }
+      its('create_date') { should be > Time.now - 365 * 86400 }
+      its('last_used_date') { should be > Time.now - 90 * 86400 }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that an IAM access key is not active
+
+    describe aws_iam_access_key(username: 'username', id: 'access-key-id') do
+      it { should_not be_active }
+    end
+
+### Test that an IAM access key is older than one year
+
+    describe aws_iam_access_key(username: 'username', id: 'access-key-id') do
+      its('create_date') { should be > Time.now - 365 * 86400 }
+    end
+
+### Test that an IAM access key has been used in the past 90 days
+
+    describe aws_iam_access_key(username: 'username', id: 'access-key-id') do
+      its('last_used_date') { should be > Time.now - 90 * 86400 }
+    end
+
+<br>
+
+## Matchers
+
+For a full list of available matchers (such as `exist`) please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/docs/resources/aws_iam_access_key.md
+++ b/docs/resources/aws_iam_access_key.md
@@ -47,4 +47,10 @@ The following examples show how to use this InSpec audit resource.
 
 ## Matchers
 
-For a full list of available matchers (such as `exist`) please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of available matchers (such as `exist`) please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### be_active
+
+The `be_active` matcher tests if the described IAM access key is active
+
+  it { should be_active }

--- a/docs/resources/aws_iam_password_policy.md
+++ b/docs/resources/aws_iam_password_policy.md
@@ -1,0 +1,69 @@
+---
+title: About the aws_iam_password_policy Resource
+---
+
+# aws_iam_password_policy
+
+Use the `aws_iam_password_policy` InSpec audit resource to test properties of the AWS IAM Password Policy
+
+<br>
+
+## Syntax
+
+An `aws_iam_password_policy` resource block takes no parameters, but uses several matchers
+
+    describe aws_iam_password_policy do
+      its('requires_lowercase_characters?') { should be true }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that the IAM Password Policy requires lowercase characters, uppercase characters, numbers, symbols, and a minimum length greater than eight
+
+    describe aws_iam_password_policy do
+      its('requires_lowercase_characters?') { should be true }
+      its('requires_uppercase_characters?') { should be true }
+      its('requires_numbers?') { should be true }
+      its('requires_symbols?') { should be true }
+      its('minimum_password_length') { should be > 8 }
+    end
+
+### Test that the IAM Password Policy allows users to change their password
+
+    describe aws_iam_password_policy do
+      its('allows_user_to_change_password?') { should be true }
+    end
+
+### Test that the IAM Password Policy expires passwords
+
+    describe aws_iam_password_policy do
+      its('expires_passwords?') { should be true }
+    end
+
+### Test that the IAM Password Policy has a max password age
+
+    describe aws_iam_password_policy do
+      its('max_password_age') { should be > 90 * 86400 }
+    end
+
+### Test that the IAM Password Policy prevents password reuse
+
+    describe aws_iam_password_policy do
+      its('prevents_password_reuse?') { should be true }
+    end
+
+### Test that the IAM Password Policy requires users to remember 3 previous passwords
+
+    describe aws_iam_password_policy do
+      its('number_of_passwords_to_remember') { should eq 3 }
+    end
+
+<br>
+
+## Matchers
+
+For a full list of available matchers (such as `exist`) please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/docs/resources/aws_iam_root_user.md
+++ b/docs/resources/aws_iam_root_user.md
@@ -1,0 +1,45 @@
+---
+title: About the aws_iam_root_user Resource
+---
+
+# aws_iam_root_user
+
+Use the `aws_iam_root_user` InSpec audit resource to test properties of the root user (owner of the accout).
+
+To test properties of all or multiple users, use the `aws_iam_users` resource.
+
+To test properties of a specific AWS user use the `aws_iam_user` resource.
+
+<br>
+
+## Syntax
+
+An `aws_iam_root_user` resource block requires no parameters but has several matchers
+
+    describe aws_iam_root_user do
+      its('has_mfa_enabled?') { should be true }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that the AWS root account has only one access key
+
+    describe aws_iam_root_user do
+      its('access_key_count') { should eq 1 }
+    end
+
+### Test that the AWS root account has Multi Factor Authentication enabled
+
+    describe aws_iam_root_user do
+      its('has_mfa_enabled?') { should be true }
+    end
+
+<br>
+
+## Matchers
+
+For a full list of available matchers (such as `eq`) please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/docs/resources/aws_iam_root_user.md
+++ b/docs/resources/aws_iam_root_user.md
@@ -17,7 +17,7 @@ To test properties of a specific AWS user use the `aws_iam_user` resource.
 An `aws_iam_root_user` resource block requires no parameters but has several matchers
 
     describe aws_iam_root_user do
-      its('has_mfa_enabled?') { should be true }
+      its { should have_mfa_enabled }
     end
 
 <br>
@@ -32,14 +32,20 @@ The following examples show how to use this InSpec audit resource.
       its('access_key_count') { should eq 1 }
     end
 
-### Test that the AWS root account has Multi Factor Authentication enabled
+### Test that the AWS root account has Multi-Factor Authentication enabled
 
     describe aws_iam_root_user do
-      its('has_mfa_enabled?') { should be true }
+      it { should have_mfa_enabled }
     end
 
 <br>
 
 ## Matchers
 
-For a full list of available matchers (such as `eq`) please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of available matchers (such as `exist`) please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### have_mfa_enabled
+
+The `have_mfa_enabled` matcher tests if the AWS root user has Multi-Factor Authentication enabled, requiring them to enter a secondary code when they login to the web console.
+
+    it { should have_mfa_enabled }

--- a/docs/resources/aws_iam_user.md
+++ b/docs/resources/aws_iam_user.md
@@ -26,18 +26,20 @@ An `aws_iam_user` resource block declares a user by name, and then lists tests t
 
 The following examples show how to use this InSpec audit resource.
 
-### Ensure a user does not exist
+### Test that a user does not exist
 
     describe aws_iam_user(name: 'gone') do
       it { should_not exist }
     end
 
-### Ensure that a user has multi-factor authentication enabled
+### Test that a user has multi-factor authentication enabled
+
     describe aws_iam_user(name: 'test_user') do
       it { should have_mfa_enabled }
     end
 
-### Ensure that a service user does not have a password
+### Test that a service user does not have a password
+
     describe aws_iam_user(name: 'test_user') do
       it { should have_console_password }
     end

--- a/docs/resources/aws_iam_users.md
+++ b/docs/resources/aws_iam_users.md
@@ -1,0 +1,45 @@
+---
+title: About the aws_iam_users Resource
+---
+
+# aws_iam_users
+
+Use the `aws_iam_userss` InSpec audit resource to test properties of a all or multiple users.
+
+To test properties of a single user, use the `aws_iam_user` resource.
+
+To test properties of the special AWS root user (which owns the account), use the `aws_iam_root_user` resource.
+
+<br>
+
+## Syntax
+
+An `aws_iam_users` resource block users a filter to select a group of users and then tests that group
+
+    describe aws_iam_users.where(has_mfa_enabled?: false) do
+      it { should_not exist }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that all users have Multi Factor Authentication enabled
+
+    describe aws_iam_users.where(has_mfa_enabled?: false) do
+      it { should_not exist }
+    end
+
+### Test that at least one user has a console password to log into the AWS web console
+
+    describe aws_iam_users.where(has_console_password?: true) do
+      it { should exist }
+    end
+
+<br>
+
+## Matchers
+
+For a full list of available matchers (such as `exist`) please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/docs/resources/aws_iam_users.md
+++ b/docs/resources/aws_iam_users.md
@@ -26,7 +26,7 @@ An `aws_iam_users` resource block users a filter to select a group of users and 
 
 The following examples show how to use this InSpec audit resource.
 
-### Test that all users have Multi Factor Authentication enabled
+### Test that all users have Multi-Factor Authentication enabled
 
     describe aws_iam_users.where(has_mfa_enabled?: false) do
       it { should_not exist }
@@ -38,8 +38,26 @@ The following examples show how to use this InSpec audit resource.
       it { should exist }
     end
 
+### Test that all users that have a console password have Multi-Factor Authentication enabled
+
+    describe aws_iam_users.where(has_console_password?: true) do
+      it { should have_mfa_enabled }
+    end
+
 <br>
 
 ## Matchers
 
-For a full list of available matchers (such as `exist`) please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of available matchers (such as `exist`) please visit our [matchers page](https://www.inspec.io/docs/reference/matchers/).
+
+### have_console_password
+
+The `have_console_password` matcher tests if the users have a password that could be used to log into the AWS web console.
+
+    it { should have_console_password }
+
+### have_mfa_enabled
+
+The `have_mfa_enabled` matcher tests if the users have Multi-Factor Authentication enabled, requiring them to enter a secondary code when they login to the web console.
+
+    it { should have_mfa_enabled }


### PR DESCRIPTION
This adds documentation for the following resources:

  - aws_ec2_instance
  - aws_iam_access_key
  - aws_iam_password_policy
  - aws_iam_root_user
  - aws_iam_users

Signed-off-by: Jerry Aldrich <jerryaldrichiii@gmail.com>