### PR TITLE
[DO NOT MERGE] Update to AWS SDK v3 and modularize requires

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,9 @@ gem 'highline', '~> 1.6.0'
 gem 'nokogiri'
 gem 'minitest', '5.10.1'
 
+gem 'aws-sdk-core', '~> 3.6'
 gem 'aws-sdk-iam', '~> 1.3'
+gem 'aws-sdk-ec2', '~> 1.12'
 
 group :tools do
   gem 'github_changelog_generator', '~> 1.12.0'

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem 'minitest', '5.10.1'
 gem 'aws-sdk-core', '~> 3.6'
 gem 'aws-sdk-iam', '~> 1.3'
 gem 'aws-sdk-ec2', '~> 1.12'
+gem 'aws-sdk-cloudwatch', '~> 1.2'
+gem 'aws-sdk-sns', '~> 1.1'
 
 group :tools do
   gem 'github_changelog_generator', '~> 1.12.0'

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,10 @@ gem 'rake'
 gem 'inspec', '~> 1'
 gem 'rubocop', '~> 0.44.0'
 gem 'highline', '~> 1.6.0'
-gem 'aws-sdk', '~> 2'
 gem 'nokogiri'
 gem 'minitest', '5.10.1'
+
+gem 'aws-sdk-iam', '~> 1.3'
 
 group :tools do
   gem 'github_changelog_generator', '~> 1.12.0'

--- a/libraries/aws_conn.rb
+++ b/libraries/aws_conn.rb
@@ -2,7 +2,10 @@
 
 class AWSConnection
   def initialize
-    require 'aws-sdk'
+    require 'aws-sdk-core'
+    require 'aws-sdk-iam'
+    require 'aws-sdk-ec2'
+
     opts = {
       region: ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'],
       credentials: Aws::Credentials.new(

--- a/libraries/aws_iam_password_policy.rb
+++ b/libraries/aws_iam_password_policy.rb
@@ -1,7 +1,5 @@
 # author: Viktor Yakovlyev
 
-require 'aws_conn'
-
 class AwsIamPasswordPolicy < Inspec.resource(1)
   name 'aws_iam_password_policy'
   desc 'Verifies iam password policy'

--- a/test/unit/helper.rb
+++ b/test/unit/helper.rb
@@ -4,5 +4,7 @@ require 'minitest/pride'
 
 require 'inspec/resource'
 
-# Needed for exception classes, etc
-require 'aws-sdk'
+require 'aws-sdk-cloudwatch'
+require 'aws-sdk-sns'
+require 'aws-sdk-ec2'
+require 'aws-sdk-iam'

--- a/test/unit/resources/aws_iam_access_key_test.rb
+++ b/test/unit/resources/aws_iam_access_key_test.rb
@@ -1,6 +1,6 @@
 # author: Chris Redekop
 
-require 'aws-sdk'
+require 'aws-sdk-iam'
 require 'helper'
 
 require 'aws_iam_access_key'

--- a/test/unit/resources/aws_iam_access_key_test.rb
+++ b/test/unit/resources/aws_iam_access_key_test.rb
@@ -1,6 +1,5 @@
 # author: Chris Redekop
 
-require 'aws-sdk-iam'
 require 'helper'
 
 require 'aws_iam_access_key'

--- a/test/unit/resources/aws_iam_password_policy_test.rb
+++ b/test/unit/resources/aws_iam_password_policy_test.rb
@@ -1,6 +1,6 @@
 require 'helper'
 require 'aws_iam_password_policy'
-require 'aws-sdk'
+require 'aws-sdk-iam'
 require 'json'
 
 class AwsIamPasswordPolicyTest < Minitest::Test

--- a/test/unit/resources/aws_iam_password_policy_test.rb
+++ b/test/unit/resources/aws_iam_password_policy_test.rb
@@ -1,6 +1,6 @@
+
 require 'helper'
 require 'aws_iam_password_policy'
-require 'aws-sdk-iam'
 require 'json'
 
 class AwsIamPasswordPolicyTest < Minitest::Test

--- a/test/unit/resources/aws_iam_root_user_test.rb
+++ b/test/unit/resources/aws_iam_root_user_test.rb
@@ -1,4 +1,5 @@
 # author: Miles Tjandrawidjaja
+
 require 'helper'
 require 'aws_iam_root_user'
 

--- a/test/unit/resources/aws_iam_user_details_provider_test.rb
+++ b/test/unit/resources/aws_iam_user_details_provider_test.rb
@@ -1,6 +1,6 @@
 # author: Adnan Duric
 # author: Steffanie Freeman
-require 'aws-sdk'
+
 require 'helper'
 require 'aws_iam_user_provider'
 require 'aws_iam_user_details_provider'

--- a/test/unit/resources/aws_iam_user_provider_test.rb
+++ b/test/unit/resources/aws_iam_user_provider_test.rb
@@ -2,7 +2,7 @@
 # author: Jeffrey Lyons
 # author: Steffanie Freeman
 # author: Alex Bedley
-require 'aws-sdk'
+require 'aws-sdk-iam'
 require 'helper'
 require 'aws_iam_user_provider'
 

--- a/test/unit/resources/aws_iam_user_provider_test.rb
+++ b/test/unit/resources/aws_iam_user_provider_test.rb
@@ -2,7 +2,7 @@
 # author: Jeffrey Lyons
 # author: Steffanie Freeman
 # author: Alex Bedley
-require 'aws-sdk-iam'
+
 require 'helper'
 require 'aws_iam_user_provider'
 

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -1,5 +1,5 @@
 # author: Simon Varlow
-require 'aws-sdk'
+require 'aws-sdk-iam'
 require 'helper'
 require 'aws_iam_user'
 

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -1,5 +1,5 @@
 # author: Simon Varlow
-require 'aws-sdk-iam'
+
 require 'helper'
 require 'aws_iam_user'
 

--- a/test/unit/resources/aws_iam_users_test.rb
+++ b/test/unit/resources/aws_iam_users_test.rb
@@ -2,7 +2,7 @@
 # author: Steffanie Freeman
 # author: Simon Varlow
 # author: Chris Redekop
-require 'aws-sdk'
+require 'aws-sdk-iam'
 require 'helper'
 require 'aws_iam_users'
 

--- a/test/unit/resources/aws_iam_users_test.rb
+++ b/test/unit/resources/aws_iam_users_test.rb
@@ -2,7 +2,7 @@
 # author: Steffanie Freeman
 # author: Simon Varlow
 # author: Chris Redekop
-require 'aws-sdk-iam'
+
 require 'helper'
 require 'aws_iam_users'
 

--- a/test/unit/resources/aws_sns_topic_test.rb
+++ b/test/unit/resources/aws_sns_topic_test.rb
@@ -22,13 +22,13 @@ class AwsSnsTopicConstructorTest < Minitest::Test
   end
 
   def test_constructor_accepts_arn_as_hash
-    AwsSnsTopic.new(arn: 'arn:aws:sns:us-east-1:123456789012:some-topic')    
+    AwsSnsTopic.new(arn: 'arn:aws:sns:us-east-1:123456789012:some-topic')
   end
-  
+
   def test_constructor_rejects_unrecognized_resource_params
     assert_raises(ArgumentError) { AwsSnsTopic.new(beep: 'boop') }
   end
-    
+
   def test_constructor_rejects_non_arn_formats
     [
       'not-even-like-an-arn',
@@ -58,7 +58,7 @@ class AwsSnsTopicRecallTest < Minitest::Test
   end
 
   def test_recall_match_single_result_works
-    AwsSnsTopic::Backend.select(AwsMSNB::NoSubscriptions)    
+    AwsSnsTopic::Backend.select(AwsMSNB::NoSubscriptions)
     topic = AwsSnsTopic.new('arn:aws:sns:us-east-1:123456789012:does-not-matter')
     assert topic.exists?
   end
@@ -104,7 +104,7 @@ module AwsMSNB
     def get_topic_attributes(_criteria)
       OpenStruct.new({
         attributes: { # Note that this is a plain hash, odd for AWS SDK
-          # Many other attributes available, see 
+          # Many other attributes available, see
           # http://docs.aws.amazon.com/sdkforruby/api/Aws/SNS/Types/GetTopicAttributesResponse.html
           "SubscriptionsConfirmed" => 0
         }
@@ -116,7 +116,7 @@ module AwsMSNB
     def get_topic_attributes(_criteria)
       OpenStruct.new({
         attributes: { # Note that this is a plain hash, odd for AWS SDK
-          # Many other attributes available, see 
+          # Many other attributes available, see
           # http://docs.aws.amazon.com/sdkforruby/api/Aws/SNS/Types/GetTopicAttributesResponse.html
           "SubscriptionsConfirmed" => 1
         }


### PR DESCRIPTION
This PR pins the AWS SDK components to the v3 (core) series, accepting minor version changes.

Current codebase needs modules core, ec2, and iam.  As new services are touched, we'll need to add deps for additional modules in `Gemfile` and a require in `libraries/aws_conn.rb`.

The migration from v2 => v3 was painless - it is only packaged differently; all classes and methods are the same.  Aside from `require`, no changes to the codebase were required.  Unit and integration tests pass for me.

Fixes #108 

This change may have impact on other Chef products.  See https://github.com/chef/inspec/issues/2258 