### PR TITLE
Add Cloudwatch Log Metric Filter resource

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ MethodLength:
   Max: 40
 NumericLiterals:
   MinDigits: 10
+Metrics/LineLength:
+  Enabled: true
+  Max: 100
 Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/PerceivedComplexity:
@@ -41,6 +44,8 @@ Style/PercentLiteralDelimiters:
     '%W': ()
     '%x': ()
 Style/AlignHash:
+  Enabled: false
+Style/IndentHash:
   Enabled: false
 Style/PredicateName:
   Enabled: false

--- a/docs/resources/aws_cloudwatch_log_metric_filter.md
+++ b/docs/resources/aws_cloudwatch_log_metric_filter.md
@@ -6,9 +6,7 @@ title: About the aws_cloudwatch_log_metric_filter Resource
 
 Use the `aws_cloudwatch_log_metric_filter` InSpec audit resource to search for and test properties of individual AWS Cloudwatch Log Metric Filters.
 
-A Log Metric Filter (LMF) is an AWS resource that observes log traffic, looks for a specified pattern, and updates metrics about the number times the match occurs.  The metrics can also be connected to AWS Cloudwatch Alarms, so that actions can be taken when a match occurs.
-
-An LMF can have multiple output metrics.
+A Log Metric Filter (LMF) is an AWS resource that observes log traffic, looks for a specified pattern, and updates a metric about the number times the match occurs.  The metric can also be connected to AWS Cloudwatch Alarms, so that actions can be taken when a match occurs.
 
 <br>
 
@@ -33,12 +31,6 @@ An `aws_cloudwatch_log_metric_filter` resource block searches for an LMF, specif
     ) do
       it { should exist }
     end
-
-<br>
-
-## Examples
-
-The following examples show how to use this InSpec audit resource.
 
 <br>
 
@@ -76,7 +68,15 @@ The filter pattern used to match entries from the logs in the log group.
 
 ## Matchers
 
-This InSpec audit resource has no custom matchers.
+### exist
+
+Matches (i.e., passes the test) if the resource parameters (search criteria) were able to locate exactly one LMF.
+
+    describe aws_cloudwatch_log_metric_filter(
+      log_group_name: 'my-log-group',
+    ) do
+      it { should exist }
+    end
 
 ## Properties
 

--- a/docs/resources/aws_cloudwatch_log_metric_filter.md
+++ b/docs/resources/aws_cloudwatch_log_metric_filter.md
@@ -1,0 +1,130 @@
+---
+title: About the aws_cloudwatch_log_metric_filter Resource
+---
+
+# aws_cloudwatch_log_metric_filter
+
+Use the `aws_cloudwatch_log_metric_filter` InSpec audit resource to search for and test properties of individual AWS Cloudwatch Log Metric Filters.
+
+A Log Metric Filter (LMF) is an AWS resource that observes log traffic, looks for a specified pattern, and updates metrics about the number times the match occurs.  The metrics can also be connected to AWS Cloudwatch Alarms, so that actions can be taken when a match occurs.
+
+An LMF can have multiple output metrics.
+
+<br>
+
+## Syntax
+
+An `aws_cloudwatch_log_metric_filter` resource block searches for an LMF, specified by several search options.  If more than one log metric filter matches, an error occurs.
+
+    # Look for a LMF by its filter name and log group name.  This combination
+    # will always either find at most one LMF - no duplicates.
+    describe aws_cloudwatch_log_metric_filter(
+      filter_name: 'my-filter',
+      log_group_name: 'my-log-group'
+    ) do
+      it { should exist }
+    end
+
+    # Search for an LMF by pattern and log group.
+    # This could result in an error if the results are not unique.
+    describe aws_cloudwatch_log_metric_filter(
+      log_group_name:  'my-log-group',
+      pattern: 'my-filter'
+    ) do
+      it { should exist }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+<br>
+
+## Resource Parameters
+
+### filter_name
+
+This is the identifier of the log metric filter within its log group.  To ensure you have a unique result, you must also provide the log_group_name.
+
+    describe aws_cloudwatch_log_metric_filter(
+      filter_name: 'my-filter'
+    ) do
+      it { should exist }
+    end
+
+### log_group_name
+
+The name of the Cloudwatch Log Group that the LMF is watching.  Together with filter_name, this uniquely identifies an LMF.
+
+    describe aws_cloudwatch_log_metric_filter(
+      log_group_name: 'my-log-group',
+    ) do
+      it { should exist }
+    end
+
+### pattern
+
+The filter pattern used to match entries from the logs in the log group.
+
+    describe aws_cloudwatch_log_metric_filter(
+      pattern: '"ERROR" - "Exiting"',
+    ) do
+      it { should exist }
+    end
+
+## Matchers
+
+This InSpec audit resource has no custom matchers.
+
+## Properties
+
+### filter_name
+
+The name of the LMF within the log_group.
+
+    # Check the name of the LMF that has a certain pattern
+    describe aws_cloudwatch_log_metric_filter(
+      log_group_name: 'app-log-group',
+      pattern: 'KERBLEWIE',
+    ) do
+      its('filter_name') { should be('kaboom_lmf') }
+    end
+
+### log_group_name
+
+The name of the log group that the LMF is watching.
+
+    # Check which log group the LMF 'error-watcher' is watching 
+    describe aws_cloudwatch_log_metric_filter(
+      filter_name: 'error-watcher',
+    ) do
+      its('log_group_name') { should be('app-log-group') }
+    end
+
+### metric_name, metric_namespace
+
+The name and namespace of the Cloudwatch Metric that will be updated when the LMF matches.  You also need the `metric_namespace` to uniquely identify the metric.
+
+    # Ensure that the LMF has the right metric name
+    describe aws_cloudwatch_log_metric_filter(
+      filter_name: 'my-filter',
+      log_group_name: 'my-log-group',
+    ) do
+      its('metric_name') { should be 'MyMetric' }
+      its('metric_namespace') { should be 'MyFantasticMetrics' }
+    end
+
+### pattern
+
+The pattern used to match entries from the logs in the log group.
+
+    # Ensure that the LMF is watching for errors
+    describe aws_cloudwatch_log_metric_filter(
+      filter_name: 'error-watcher',
+      log_group_name: 'app-log-group',
+    ) do
+      its('pattern') { should be('ERROR') }
+    end
+

--- a/docs/resources/aws_cloudwatch_log_metric_filter.md
+++ b/docs/resources/aws_cloudwatch_log_metric_filter.md
@@ -89,7 +89,7 @@ The name of the LMF within the log_group.
       log_group_name: 'app-log-group',
       pattern: 'KERBLEWIE',
     ) do
-      its('filter_name') { should be('kaboom_lmf') }
+      its('filter_name') { should cmp 'kaboom_lmf' }
     end
 
 ### log_group_name
@@ -100,7 +100,7 @@ The name of the log group that the LMF is watching.
     describe aws_cloudwatch_log_metric_filter(
       filter_name: 'error-watcher',
     ) do
-      its('log_group_name') { should be('app-log-group') }
+      its('log_group_name') { should cmp 'app-log-group' }
     end
 
 ### metric_name, metric_namespace
@@ -112,8 +112,8 @@ The name and namespace of the Cloudwatch Metric that will be updated when the LM
       filter_name: 'my-filter',
       log_group_name: 'my-log-group',
     ) do
-      its('metric_name') { should be 'MyMetric' }
-      its('metric_namespace') { should be 'MyFantasticMetrics' }
+      its('metric_name') { should cmp 'MyMetric' }
+      its('metric_namespace') { should cmp 'MyFantasticMetrics' }
     end
 
 ### pattern
@@ -125,6 +125,6 @@ The pattern used to match entries from the logs in the log group.
       filter_name: 'error-watcher',
       log_group_name: 'app-log-group',
     ) do
-      its('pattern') { should be('ERROR') }
+      its('pattern') { should cmp 'ERROR' }
     end
 

--- a/libraries/aws_cloudwatch_log_metric_filter.rb
+++ b/libraries/aws_cloudwatch_log_metric_filter.rb
@@ -23,6 +23,33 @@ class AwsCloudwatchLogMetricFilter < Inspec.resource(1)
   end
 EOX
 
+  RESOURCE_PARAMS = [
+    :filter_name,
+    :log_group_name,
+    :pattern,
+  ].freeze
+
+  def initialize(resource_params)
+    resource_params = validate_resource_params(resource_params)
+  end
+
+  private
+  def validate_resource_params(resource_params)
+    unless resource_params.is_a? Hash
+      raise ArgumentError.new(
+        'Unrecognized format for aws_cloudwatch_log_metric_filter parameters ' \
+        " - use (param: 'value') format "
+      )
+    end
+    resource_params.keys.each do |param_name|
+      unless RESOURCE_PARAMS.include?(param_name)
+        raise ArgumentError.new(
+          "Unrecognized parameter '#{param_name}' for aws_cloudwatch_log_metric_filter." \
+          " Expected one of #{RESOURCE_PARAMS.join(', ')}."
+        )
+      end
+    end
+  end
 
   class Backend
     #=====================================================#

--- a/libraries/aws_cloudwatch_log_metric_filter.rb
+++ b/libraries/aws_cloudwatch_log_metric_filter.rb
@@ -1,0 +1,66 @@
+require 'aws_conn'
+
+class AwsCloudwatchLogMetricFilter < Inspec.resource(1)
+  name 'aws_cloudwatch_log_metric_filter'
+  desc 'Verifies individual Cloudwatch Log Metric Filters'
+  example <<-EOX
+  # Look for a LMF by its filter name and log group name.  This combination
+  # will always either find at most one LMF - no duplicates.
+  describe aws_cloudwatch_log_metric_filter(
+    filter_name: 'my-filter',
+    log_group_name: 'my-log-group'
+  ) do
+    it { should exist }
+  end
+
+  # Search for an LMF by pattern and log group.
+  # This could result in an error if the results are not unique.
+  describe aws_cloudwatch_log_metric_filter(
+    log_group_name:  'my-log-group',
+    pattern: 'my-filter'
+  ) do
+    it { should exist }
+  end
+EOX
+
+
+  class Backend
+    #=====================================================#
+    #                    API Definition
+    #=====================================================#
+    [
+    ].each do |method|
+      define_method(:method) do |*_args|
+        raise "Unimplemented abstract method #{method} - internal error" 
+      end 
+    end
+
+    #=====================================================#
+    #                 Concrete Implementation
+    #=====================================================#
+    # Uses the cloudwatch API to really talk to AWS
+    class AwsClientApi
+    end
+
+    
+
+    #=====================================================#
+    #                   Factory Interface
+    #=====================================================#
+    # TODO: move this to a mix-in
+    DEFAULT_BACKEND = AwsClientApi
+    @selected_backend = DEFAULT_BACKEND
+
+    def self.create
+      @selected_backend.new
+    end
+
+    def self.select(klass)
+      @selected_backend = klass
+    end
+
+    def self.reset
+      select(DEFAULT_BACKEND)
+    end
+  end
+end

--- a/libraries/aws_cloudwatch_log_metric_filter.rb
+++ b/libraries/aws_cloudwatch_log_metric_filter.rb
@@ -114,6 +114,17 @@ EOX
     #=====================================================#
     # Uses the cloudwatch API to really talk to AWS
     class AwsClientApi < Backend
+      def describe_metric_filters(criteria)
+        cwl_client = AWSConnection.new.cloudwatch_logs_client
+        query = {}
+        query[:filter_name_prefix] = criteria[:filter_name] if criteria[:filter_name]
+        query[:log_group_name] = criteria[:log_group_name] if criteria[:log_group_name]
+        # 'pattern' is not available as a remote filter, 
+        # we filter it after the fact locally
+        # TODO: handle pagination?  Max 50/page.  Maybe you want a plural resource?
+        aws_response = cwl_client.describe_metric_filters(query)
+        aws_response.metric_filters
+      end
     end
 
     #=====================================================#

--- a/libraries/aws_cloudwatch_log_metric_filter.rb
+++ b/libraries/aws_cloudwatch_log_metric_filter.rb
@@ -36,7 +36,7 @@ EOX
     results = run_lmf_search(resource_params)
     if results.count > 1
       raise 'More than one result was returned, but aws_cloudwatch_log_metric_filter '\
-            'can only handle an individual AWS resource.  Consider passing more resource '\
+            'can only handle a single AWS resource.  Consider passing more resource '\
             'parameters to narrow down the search.'
     else
       unpack_search_results(results)

--- a/libraries/aws_cloudwatch_log_metric_filter.rb
+++ b/libraries/aws_cloudwatch_log_metric_filter.rb
@@ -30,7 +30,7 @@ EOX
   ].freeze
 
   attr_reader :found, :filter_name, :log_group_name, :pattern, :metric_name, :metric_namespace
-  
+
   def initialize(resource_params)
     resource_params = validate_resource_params(resource_params)
     results = run_lmf_search(resource_params)
@@ -38,7 +38,7 @@ EOX
       raise 'More than one result was returned, but aws_cloudwatch_log_metric_filter '\
             'can only handle an individual AWS resource.  Consider passing more resource '\
             'parameters to narrow down the search.'
-    else 
+    else
       unpack_search_results(results)
     end
   end
@@ -48,18 +48,21 @@ EOX
   end
 
   private
+
   def validate_resource_params(resource_params)
     unless resource_params.is_a? Hash
-      raise ArgumentError.new(
+      raise(
+        ArgumentError, \
         'Unrecognized format for aws_cloudwatch_log_metric_filter parameters ' \
-        " - use (param: 'value') format "
+        " - use (param: 'value') format ",
       )
     end
     resource_params.keys.each do |param_name|
-      unless RESOURCE_PARAMS.include?(param_name)
-        raise ArgumentError.new(
+      unless RESOURCE_PARAMS.include?(param_name) # rubocop:disable Style/Next
+        raise(
+          ArgumentError, \
           "Unrecognized parameter '#{param_name}' for aws_cloudwatch_log_metric_filter." \
-          " Expected one of #{RESOURCE_PARAMS.join(', ')}."
+          " Expected one of #{RESOURCE_PARAMS.join(', ')}.",
         )
       end
     end
@@ -67,13 +70,13 @@ EOX
   end
 
   def run_lmf_search(criteria)
-    # get a backend    
-    backend = AwsCloudwatchLogMetricFilter::Backend.create()
-    # Perform query with remote filtering    
+    # get a backend
+    backend = AwsCloudwatchLogMetricFilter::Backend.create
+    # Perform query with remote filtering
     aws_results = backend.describe_metric_filters(criteria)
     # Then perform local filtering
     if criteria.key?(:pattern)
-      aws_results.select! {|lmf| lmf.filter_pattern == criteria[:pattern]}
+      aws_results.select! { |lmf| lmf.filter_pattern == criteria[:pattern] }
     end
     # Finally remap to an array of single-level hash
     aws_results.map do |lmf|
@@ -102,11 +105,11 @@ EOX
     #                    API Definition
     #=====================================================#
     [
-      :describe_metric_filters
+      :describe_metric_filters,
     ].each do |method|
       define_method(:method) do |*_args|
-        raise "Unimplemented abstract method #{method} - internal error" 
-      end 
+        raise "Unimplemented abstract method #{method} - internal error"
+      end
     end
 
     #=====================================================#
@@ -119,7 +122,7 @@ EOX
         query = {}
         query[:filter_name_prefix] = criteria[:filter_name] if criteria[:filter_name]
         query[:log_group_name] = criteria[:log_group_name] if criteria[:log_group_name]
-        # 'pattern' is not available as a remote filter, 
+        # 'pattern' is not available as a remote filter,
         # we filter it after the fact locally
         # TODO: handle pagination?  Max 50/page.  Maybe you want a plural resource?
         aws_response = cwl_client.describe_metric_filters(query)

--- a/libraries/aws_conn.rb
+++ b/libraries/aws_conn.rb
@@ -17,7 +17,7 @@ class AWSConnection
   def sns_client
     @sns_client ||= Aws::SNS::Client.new
   end
-  
+
   def cloudwatch_logs_client
     @cloudwatch_logs_client ||= Aws::CloudWatchLogs::Client.new
   end

--- a/libraries/aws_conn.rb
+++ b/libraries/aws_conn.rb
@@ -17,6 +17,10 @@ class AWSConnection
   def sns_client
     @sns_client ||= Aws::SNS::Client.new
   end
+  
+  def cloudwatch_logs_client
+    @cloudwatch_logs_client ||= Aws::CloudWatchLogs::Client.new
+  end
 
   def ec2_resource
     @ec2_resource ||= Aws::EC2::Resource.new

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -84,7 +84,7 @@ resource "aws_cloudwatch_log_group" "lmf_lg_2" {
 
 resource "aws_cloudwatch_log_metric_filter" "lmf_1" {
   name           = "${terraform.env}_lmf"
-  pattern        = "kitteh"
+  pattern        = "testpattern01"
   log_group_name = "${aws_cloudwatch_log_group.lmf_lg_1.name}"
 
   metric_transformation {
@@ -96,7 +96,7 @@ resource "aws_cloudwatch_log_metric_filter" "lmf_1" {
 
 resource "aws_cloudwatch_log_metric_filter" "lmf_2" {
   name           = "${terraform.env}_lmf"
-  pattern        = "kittehcat"
+  pattern        = "testpattern02"
   log_group_name = "${aws_cloudwatch_log_group.lmf_lg_2.name}"
 
   metric_transformation {

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -73,6 +73,59 @@ resource "aws_iam_access_key" "access_key" {
   pgp_key = "${var.login_profile_pgp_key}"
 }
 
+resource "aws_cloudwatch_log_group" "lmf_lg_1" {
+  name = "${terraform.env}_lmf_lg_1"
+}
+
+# We make a separate log group to test uniqueness of LMF identifiers
+resource "aws_cloudwatch_log_group" "lmf_lg_2" {
+  name = "${terraform.env}_lmf_lg_2"
+}
+
+resource "aws_cloudwatch_log_metric_filter" "lmf_1" {
+  name           = "${terraform.env}_lmf"
+  pattern        = "kitteh"
+  log_group_name = "${aws_cloudwatch_log_group.lmf_lg_1.name}"
+
+  metric_transformation {
+    name      = "${terraform.env}_KittehCount_1"
+    namespace = "${terraform.env}_YourNamespace_1"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "lmf_2" {
+  name           = "${terraform.env}_lmf"
+  pattern        = "kittehcat"
+  log_group_name = "${aws_cloudwatch_log_group.lmf_lg_2.name}"
+
+  metric_transformation {
+    name      = "${terraform.env}_KittehCount_3"
+    namespace = "${terraform.env}_YourNamespace_3"
+    value     = "1"
+  }
+}
+
+output "lmf_1_name" {
+  value = "${aws_cloudwatch_log_metric_filter.lmf_1.name}"
+}
+
+output "lmf_2_name" {
+  value = "${aws_cloudwatch_log_metric_filter.lmf_2.name}"
+}
+
+output "lmf_1_metric_1_name" {
+  value = "${terraform.env}_KittehCount_1"
+}
+
+output "lmf_lg_1_name" {
+  value = "${aws_cloudwatch_log_group.lmf_lg_1.name}"
+}
+
+output "lmf_lg_2_name" {
+  value = "${aws_cloudwatch_log_group.lmf_lg_2.name}"
+}
+
 output "mfa_not_enabled_user" {
   value = "${aws_iam_user.mfa_not_enabled_user.name}"
 }

--- a/test/integration/verify/controls/aws_cloudwatch_log_metric_filter.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_log_metric_filter.rb
@@ -24,7 +24,7 @@ lmf_lg_2_name = attribute(
 
 lmf_1_metric_1_name = attribute(
   'lmf_1_metric_1_name',
-  default: 'default.lmf_lg_1_metric_1_name',
+  default: 'default.lmf_1_metric_1_name',
   description: 'Name of a Cloudwatch Metric',
 )
 
@@ -33,14 +33,14 @@ describe aws_cloudwatch_log_metric_filter(
   log_group_name: lmf_lg_1_name,
 ) do
   it { should exist }
-  its('pattern') { should be 'kitteh'}
-  its('metric_name') { should be lmf_lg_1_metric_1_name }
+  its('pattern') { should cmp 'kitteh'}
+  its('metric_name') { should cmp lmf_1_metric_1_name }
 end
 
 describe aws_cloudwatch_log_metric_filter(
   pattern: 'kittehcat',
 ) do
   it { should exist }
-  its('log_group_name') { should be lmf_lg_2_name }
-  its('filter_name') { should be lmf_2_name }
+  its('log_group_name') { should cmp lmf_lg_2_name }
+  its('filter_name') { should cmp lmf_2_name }
 end

--- a/test/integration/verify/controls/aws_cloudwatch_log_metric_filter.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_log_metric_filter.rb
@@ -1,0 +1,46 @@
+lmf_1_name = attribute(
+  'lmf_1_name',
+  default: 'default.lmf_1_name',
+  description: 'Name of a Cloudwatch Log Metric Filter',
+)
+
+lmf_2_name = attribute(
+  'lmf_2_name',
+  default: 'default.lmf_2_name',
+  description: 'Name of a Cloudwatch Log Metric Filter',
+)
+
+lmf_lg_1_name = attribute(
+  'lmf_lg_1_name',
+  default: 'default.lmf_lg_1_name',
+  description: 'Name of a Cloudwatch Log Group',
+)
+
+lmf_lg_2_name = attribute(
+  'lmf_lg_2_name',
+  default: 'default.lmf_lg_2_name',
+  description: 'Name of a Cloudwatch Log Group',
+)
+
+lmf_1_metric_1_name = attribute(
+  'lmf_1_metric_1_name',
+  default: 'default.lmf_lg_1_metric_1_name',
+  description: 'Name of a Cloudwatch Metric',
+)
+
+describe aws_cloudwatch_log_metric_filter(
+  filter_name: lmf_1_name,
+  log_group_name: lmf_lg_1_name,
+) do
+  it { should exist }
+  its('pattern') { should be 'kitteh'}
+  its('metric_name') { should be lmf_lg_1_metric_1_name }
+end
+
+describe aws_cloudwatch_log_metric_filter(
+  pattern: 'kittehcat',
+) do
+  it { should exist }
+  its('log_group_name') { should be lmf_lg_2_name }
+  its('filter_name') { should be lmf_2_name }
+end

--- a/test/integration/verify/controls/aws_cloudwatch_log_metric_filter.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_log_metric_filter.rb
@@ -33,12 +33,12 @@ describe aws_cloudwatch_log_metric_filter(
   log_group_name: lmf_lg_1_name,
 ) do
   it { should exist }
-  its('pattern') { should cmp 'kitteh'}
+  its('pattern') { should cmp 'testpattern01'}
   its('metric_name') { should cmp lmf_1_metric_1_name }
 end
 
 describe aws_cloudwatch_log_metric_filter(
-  pattern: 'kittehcat',
+  pattern: 'testpattern02',
 ) do
   it { should exist }
   its('log_group_name') { should cmp lmf_lg_2_name }

--- a/test/unit/resources/aws_cloudwatch_log_metric_filter_test.rb
+++ b/test/unit/resources/aws_cloudwatch_log_metric_filter_test.rb
@@ -22,7 +22,7 @@ class AwsCWLMFConstructor < Minitest::Test
       :filter_name,
       :pattern,
       :log_group_name,
-    ].each do | resource_param |
+    ].each do |resource_param|
       AwsCloudwatchLogMetricFilter.new(resource_param => 'some_val')
     end
   end
@@ -37,7 +37,7 @@ end
 #=============================================================================#
 class AwsCWLMFSearch < Minitest::Test
   def setup
-    # Reset to the Basic kit each time 
+    # Reset to the Basic kit each time
     AwsCloudwatchLogMetricFilter::Backend.select(AwsMockCWLMFBackend::Basic)
   end
 
@@ -58,9 +58,9 @@ class AwsCWLMFSearch < Minitest::Test
   end
 
   def test_using_log_group_name_resulting_in_duplicates
-    assert_raises(RuntimeError) do 
+    assert_raises(RuntimeError) do
       AwsCloudwatchLogMetricFilter.new(
-        log_group_name: 'test-log-group-01'
+        log_group_name: 'test-log-group-01',
       )
     end
   end
@@ -72,14 +72,13 @@ class AwsCWLMFSearch < Minitest::Test
     )
     assert lmf.exists?
   end
-
 end
 #=============================================================================#
 #                            Property Tests                                   #
 #=============================================================================#
-class AwsCWLMFSearch < Minitest::Test
+class AwsCWLMFProperties < Minitest::Test
   def setup
-    # Reset to the Basic kit each time 
+    # Reset to the Basic kit each time
     AwsCloudwatchLogMetricFilter::Backend.select(AwsMockCWLMFBackend::Basic)
   end
 
@@ -104,9 +103,9 @@ class AwsMockCWLMFBackend
     end
   end
   class Basic < AwsCloudwatchLogMetricFilter::Backend
-    def describe_metric_filters(criteria)
+    def describe_metric_filters(criteria) # rubocop:disable Metrics/MethodLength
       everything = [
-        OpenStruct::new({
+        OpenStruct.new({
           filter_name: 'test-01',
           filter_pattern: 'ERROR',
           log_group_name: 'test-log-group-01',
@@ -114,21 +113,21 @@ class AwsMockCWLMFBackend
             OpenStruct.new({
               metric_name: 'alpha',
               metric_namespace: 'awesome_metrics',
-            })
-          ]
+            }),
+          ],
         }),
-        OpenStruct::new({
-          filter_name: 'test-01', # Intentional duplicate 
+        OpenStruct.new({
+          filter_name: 'test-01', # Intentional duplicate
           filter_pattern: 'ERROR',
           log_group_name: 'test-log-group-02',
           metric_transformations: [
             OpenStruct.new({
               metric_name: 'beta',
               metric_namespace: 'awesome_metrics',
-            })
-          ]
+            }),
+          ],
         }),
-        OpenStruct::new({
+        OpenStruct.new({
           filter_name: 'test-03',
           filter_pattern: 'INFO',
           log_group_name: 'test-log-group-01',
@@ -136,8 +135,8 @@ class AwsMockCWLMFBackend
             OpenStruct.new({
               metric_name: 'gamma',
               metric_namespace: 'awesome_metrics',
-            })
-          ]
+            }),
+          ],
         }),
       ]
       selection = everything
@@ -145,7 +144,7 @@ class AwsMockCWLMFBackend
       # - which notably does not include the 'pattern' criteria
       [:log_group_name, :filter_name].each do |remote_filter|
         next unless criteria.key?(remote_filter)
-        selection.select! {|lmf| lmf[remote_filter] == criteria[remote_filter]}
+        selection.select! { |lmf| lmf[remote_filter] == criteria[remote_filter] }
       end
       selection
     end

--- a/test/unit/resources/aws_cloudwatch_log_metric_filter_test.rb
+++ b/test/unit/resources/aws_cloudwatch_log_metric_filter_test.rb
@@ -77,6 +77,22 @@ end
 #=============================================================================#
 #                            Property Tests                                   #
 #=============================================================================#
+class AwsCWLMFSearch < Minitest::Test
+  def setup
+    # Reset to the Basic kit each time 
+    AwsCloudwatchLogMetricFilter::Backend.select(AwsMockCWLMFBackend::Basic)
+  end
+
+  def test_property_values
+    lmf = AwsCloudwatchLogMetricFilter.new(
+      log_group_name: 'test-log-group-01',
+      filter_name: 'test-01',
+    )
+    assert_equal('ERROR', lmf.pattern)
+    assert_equal('alpha', lmf.metric_name)
+    assert_equal('awesome_metrics', lmf.metric_namespace)
+  end
+end
 
 #=============================================================================#
 #                 Support Classes - Mock Data Providers                       #
@@ -124,7 +140,6 @@ class AwsMockCWLMFBackend
           ]
         }),
       ]
-      #  byebug  
       selection = everything
       # Here we filter on anything the AWS SDK lets us filter on remotely
       # - which notably does not include the 'pattern' criteria

--- a/test/unit/resources/aws_cloudwatch_log_metric_filter_test.rb
+++ b/test/unit/resources/aws_cloudwatch_log_metric_filter_test.rb
@@ -1,0 +1,34 @@
+require 'helper'
+require 'aws_cloudwatch_log_metric_filter'
+
+# CWLMF = CloudwatchLogMetricFilter
+# Abbreviation not used outside this file
+
+class AwsCWLMFConstructor < Minitest::Test
+  def setup
+    AwsCloudwatchLogMetricFilter::Backend.select(AwsMockCWLMFBackend::Empty)
+  end
+
+  def test_constructor_some_args_required
+    assert_raises(ArgumentError) { AwsCloudwatchLogMetricFilter.new }
+  end
+
+  def test_constructor_accepts_known_resource_params
+    [
+      :filter_name,
+      :pattern,
+      :log_group_name,
+    ].each do | resource_param |
+      AwsCloudwatchLogMetricFilter.new(resource_param => 'some_val')
+    end
+  end
+
+  def test_constructor_reject_bad_resource_params
+    assert_raises(ArgumentError) { AwsCloudwatchLogMetricFilter.new(i_am_a_martian: 'beep') }
+  end
+end
+
+class AwsMockCWLMFBackend < AwsCloudwatchLogMetricFilter::Backend
+  class Empty
+  end
+end

--- a/test/unit/resources/aws_cloudwatch_log_metric_filter_test.rb
+++ b/test/unit/resources/aws_cloudwatch_log_metric_filter_test.rb
@@ -1,9 +1,13 @@
+require 'ostruct'
 require 'helper'
 require 'aws_cloudwatch_log_metric_filter'
 
 # CWLMF = CloudwatchLogMetricFilter
 # Abbreviation not used outside this file
 
+#=============================================================================#
+#                            Constructor Tests
+#=============================================================================#
 class AwsCWLMFConstructor < Minitest::Test
   def setup
     AwsCloudwatchLogMetricFilter::Backend.select(AwsMockCWLMFBackend::Empty)
@@ -28,7 +32,107 @@ class AwsCWLMFConstructor < Minitest::Test
   end
 end
 
-class AwsMockCWLMFBackend < AwsCloudwatchLogMetricFilter::Backend
-  class Empty
+#=============================================================================#
+#                             Search Tests                                    #
+#=============================================================================#
+class AwsCWLMFSearch < Minitest::Test
+  def setup
+    # Reset to the Basic kit each time 
+    AwsCloudwatchLogMetricFilter::Backend.select(AwsMockCWLMFBackend::Basic)
+  end
+
+  def test_using_lg_and_lmf_name_when_exactly_one
+    lmf = AwsCloudwatchLogMetricFilter.new(
+      log_group_name: 'test-log-group-01',
+      filter_name: 'test-01',
+    )
+    assert lmf.exists?
+  end
+
+  def test_using_lg_and_lmf_name_when_not_present
+    lmf = AwsCloudwatchLogMetricFilter.new(
+      log_group_name: 'test-log-group-01',
+      filter_name: 'test-1000-nope',
+    )
+    refute lmf.exists?
+  end
+
+  def test_using_log_group_name_resulting_in_duplicates
+    assert_raises(RuntimeError) do 
+      AwsCloudwatchLogMetricFilter.new(
+        log_group_name: 'test-log-group-01'
+      )
+    end
+  end
+
+  def test_duplicate_locally_uniqued_using_pattern
+    lmf = AwsCloudwatchLogMetricFilter.new(
+      log_group_name: 'test-log-group-01',
+      pattern: 'INFO',
+    )
+    assert lmf.exists?
+  end
+
+end
+#=============================================================================#
+#                            Property Tests                                   #
+#=============================================================================#
+
+#=============================================================================#
+#                 Support Classes - Mock Data Providers                       #
+#=============================================================================#
+class AwsMockCWLMFBackend
+  class Empty < AwsCloudwatchLogMetricFilter::Backend
+    def describe_metric_filters(_criteria)
+      []
+    end
+  end
+  class Basic < AwsCloudwatchLogMetricFilter::Backend
+    def describe_metric_filters(criteria)
+      everything = [
+        OpenStruct::new({
+          filter_name: 'test-01',
+          filter_pattern: 'ERROR',
+          log_group_name: 'test-log-group-01',
+          metric_transformations: [
+            OpenStruct.new({
+              metric_name: 'alpha',
+              metric_namespace: 'awesome_metrics',
+            })
+          ]
+        }),
+        OpenStruct::new({
+          filter_name: 'test-01', # Intentional duplicate 
+          filter_pattern: 'ERROR',
+          log_group_name: 'test-log-group-02',
+          metric_transformations: [
+            OpenStruct.new({
+              metric_name: 'beta',
+              metric_namespace: 'awesome_metrics',
+            })
+          ]
+        }),
+        OpenStruct::new({
+          filter_name: 'test-03',
+          filter_pattern: 'INFO',
+          log_group_name: 'test-log-group-01',
+          metric_transformations: [
+            OpenStruct.new({
+              metric_name: 'gamma',
+              metric_namespace: 'awesome_metrics',
+            })
+          ]
+        }),
+      ]
+      #  byebug  
+      selection = everything
+      # Here we filter on anything the AWS SDK lets us filter on remotely
+      # - which notably does not include the 'pattern' criteria
+      [:log_group_name, :filter_name].each do |remote_filter|
+        next unless criteria.key?(remote_filter)
+        selection.select! {|lmf| lmf[remote_filter] == criteria[remote_filter]}
+      end
+      selection
+    end
   end
 end


### PR DESCRIPTION
This PR implements a singular resource for Cloudwatch Logs Metric Filters (LMFs), `aws_cloudwatch_log_metric_filter`.  You can search for a LMF, uniquely identified by a log group and filter name; or you can live dangerously and search on any combination of filter pattern, group name, or filter name.  Search criteria are passed as an implicit hash in the resource parameters.

If the search returns multiple results, a RuntimeError is thrown.

If the search fails (misses), it is not an error, but the `exists` matcher will fail the test.

Documentation, unit tests, and integration tests are included.