### PR TITLE
Add aws_cloudwatch_alarm resource

### DIFF
--- a/docs/resources/aws_cloudwatch_alarm.md
+++ b/docs/resources/aws_cloudwatch_alarm.md
@@ -65,4 +65,12 @@ The control will pass if a Cloudwatch Alarm could be found. Use should_not if yo
 
 ### alarm_actions
 
-TODO
+`alarm_actions` returns a list of strings.  Each string is the ARN of an action that will be taken should the alarm be triggered.  
+
+    # Ensure that the alarm has at least one action
+    describe aws_cloudwatch_alarm(
+      metric: 'bed-metric',
+      metric_namespace: 'my-metric-namespace',
+    ) do 
+      its('alarm_actions') { should_not be_empty }
+    end

--- a/docs/resources/aws_cloudwatch_alarm.md
+++ b/docs/resources/aws_cloudwatch_alarm.md
@@ -1,0 +1,68 @@
+---
+title: About the aws_cloudwatch_alarm Resource
+---
+
+# aws_cloudwatch_alarm
+
+Use the `aws_cloudwatch_alarm` InSpec audit resource to test properties of a single Cloudwatch Alarm.
+
+Cloudwatch Alarms are currently identified using the metric name and metric namespace.  Future work may allow other approaches to identifying alarms.
+
+<br>
+
+## Syntax
+
+An `aws_cloudwatch_alarm` resource block searches for a Cloudwatch Alarm, specified by several search options.  If more than one Alarm matches, an error occurs.
+
+    # Look for a specific alarm
+    aws_cloudwatch_alarm(
+      metric: 'my-metric-name',
+      metric_namespace: 'my-metric-namespace',
+    ) do
+      it { should exist }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Ensure an Alarm has at least one alarm action
+
+    describe aws_cloudwatch_alarm(
+      metric: 'my-metric-name',
+      metric_namespace: 'my-metric-namespace',
+    ) do 
+      its('alarm_actions') { should_not be_empty }
+    end 
+
+<br>
+
+## Matchers
+
+### exists
+
+The control will pass if a Cloudwatch Alarm could be found. Use should_not if you expect zero matches.
+
+    # Expect good metric
+    describe aws_cloudwatch_alarm(
+      metric: 'good-metric',
+      metric_namespace: 'my-metric-namespace',
+    ) do 
+      it { should exist }
+    end
+
+    # Disallow alarms based on bad-metric
+    describe aws_cloudwatch_alarm(
+      metric: 'bed-metric',
+      metric_namespace: 'my-metric-namespace',
+    ) do 
+      it { should_not exist }
+    end
+
+## Properties
+
+### alarm_actions
+
+TODO

--- a/libraries/aws_cloudwatch_alarm.rb
+++ b/libraries/aws_cloudwatch_alarm.rb
@@ -14,8 +14,9 @@ class AwsCloudwatchAlarm < Inspec.resource(1)
 
   attr_reader :alarm_name, :metric_name, :metric_namespace, :alarm_actions
   def initialize(opts)
-    # Validates and sets instance variables
-    validate_resource_params(opts)
+    validate_resource_params(opts).each do |param, value|
+      instance_variable_set("@#{param}", value)
+    end
     search
   end
 
@@ -30,16 +31,19 @@ class AwsCloudwatchAlarm < Inspec.resource(1)
       raise ArgumentError, "Resource params should be passed using \"key: 'value'\" format."
     end
 
+    validated_params = {}
     # Currently you must specify exactly metric_name and metric_namespace
     [:metric_name, :metric_namespace].each do |param|
       raise ArgumentError, "Missing resource param #{param}" unless raw_params.key?(param)
-      instance_variable_set(:"@#{param}", raw_params.delete(param))
+      validated_params[param] = raw_params.delete(param)
     end
 
     # Any leftovers are unwelcome
-    unless raw_params.empty? # rubocop:disable Style/GuardClause
+    unless raw_params.empty?
       raise ArgumentError, "Unrecognized resource param '#{raw_params.keys.first}'"
     end
+
+    validated_params
   end
 
   def search

--- a/libraries/aws_cloudwatch_alarm.rb
+++ b/libraries/aws_cloudwatch_alarm.rb
@@ -12,7 +12,7 @@ class AwsCloudwatchAlarm < Inspec.resource(1)
   end
   EOD
 
-  attr_reader :exists, :alarm_name, :metric_name, :metric_namespace, :alarm_actions
+  attr_reader :alarm_name, :metric_name, :metric_namespace, :alarm_actions
   def initialize(opts)
     # Validates and sets instance variables
     validate_resource_params(opts)

--- a/libraries/aws_cloudwatch_alarm.rb
+++ b/libraries/aws_cloudwatch_alarm.rb
@@ -1,0 +1,80 @@
+require 'aws_conn'
+
+class AwsCloudwatchAlarm < Inspec.resource(1)
+  name 'aws_cloudwatch_alarm'
+  desc <<-EOD
+  # Look for a specific alarm
+  aws_cloudwatch_alarm(
+    metric: 'my-metric-name',
+    metric_namespace: 'my-metric-namespace',
+  ) do
+    it { should exist }
+  end
+  EOD
+
+  attr_reader :exists, :metric_name, :metric_namespace
+  def initialize(opts)
+    # Validates and sets instance variables
+    validate_resource_params(opts)
+  end
+
+  private
+  def validate_resource_params(raw_params)
+    unless raw_params.kind_of? Hash      
+      raise ArgumentError, "Resource params should be passed using \"key: 'value'\" format."
+    end
+
+    # Currently you must specify exactly metric_name and metric_namespace
+    [:metric_name, :metric_namespace].each do |param|
+      raise ArgumentError, "Missing resource param #{param}" unless raw_params.key?(param)
+      instance_variable_set(:"@#{param}", raw_params.delete(param))
+    end
+
+    # Any leftovers are unwelcome
+    unless raw_params.empty?
+      raise ArgumentError, "Unrecognized resource param '#{raw_params.keys.first}'"
+    end
+  end
+
+  class Backend
+    #=====================================================#
+    #                    API Definition
+    #=====================================================#
+    [
+      :describe_alarms_for_metric
+    ].each do |method|
+      define_method(:method) do |*_args|
+        raise "Unimplemented abstract method #{method} - internal error"
+      end
+    end
+
+    #=====================================================#
+    #                 Concrete Implementation
+    #=====================================================#
+    # Uses the cloudwatch API to really talk to AWS
+    class AwsClientApi < Backend
+      def describe_metric_filters(criteria)
+        raise 'Unimplemented'
+      end
+    end
+
+    #=====================================================#
+    #                   Factory Interface
+    #=====================================================#
+    # TODO: move this to a mix-in
+    DEFAULT_BACKEND = AwsClientApi
+    @selected_backend = DEFAULT_BACKEND
+
+    def self.create
+      @selected_backend.new
+    end
+
+    def self.select(klass)
+      @selected_backend = klass
+    end
+
+    def self.reset
+      select(DEFAULT_BACKEND)
+    end
+  end
+end

--- a/libraries/aws_cloudwatch_alarm.rb
+++ b/libraries/aws_cloudwatch_alarm.rb
@@ -75,8 +75,8 @@ class AwsCloudwatchAlarm < Inspec.resource(1)
     #=====================================================#
     # Uses the cloudwatch API to really talk to AWS
     class AwsClientApi < Backend
-      def describe_metric_filters(criteria)
-        raise 'Unimplemented'
+      def describe_alarms_for_metric(criteria)
+        AWSConnection.new.cloudwatch_client.describe_alarms_for_metric(criteria)
       end
     end
 

--- a/libraries/aws_cloudwatch_alarm.rb
+++ b/libraries/aws_cloudwatch_alarm.rb
@@ -19,12 +19,14 @@ class AwsCloudwatchAlarm < Inspec.resource(1)
     search
   end
 
-  alias_method :exists?, :exists
+  def exists?
+    @exists
+  end
 
   private
 
   def validate_resource_params(raw_params)
-    unless raw_params.kind_of? Hash      
+    unless raw_params.is_a? Hash
       raise ArgumentError, "Resource params should be passed using \"key: 'value'\" format."
     end
 
@@ -35,7 +37,7 @@ class AwsCloudwatchAlarm < Inspec.resource(1)
     end
 
     # Any leftovers are unwelcome
-    unless raw_params.empty?
+    unless raw_params.empty? # rubocop:disable Style/GuardClause
       raise ArgumentError, "Unrecognized resource param '#{raw_params.keys.first}'"
     end
   end
@@ -49,7 +51,7 @@ class AwsCloudwatchAlarm < Inspec.resource(1)
       @exists = false
     elsif aws_alarms.metric_alarms.count > 1
       alarms = aws_alarms.metric_alarms.map(&:alarm_name)
-      raise RuntimeError, "More than one Cloudwatch Alarm was matched. Try using " \
+      raise 'More than one Cloudwatch Alarm was matched. Try using ' \
         "more specific resource parameters. Alarms matched: #{alarms.join(', ')}"
     else
       @alarm_actions = aws_alarms.metric_alarms.first.alarm_actions
@@ -63,7 +65,7 @@ class AwsCloudwatchAlarm < Inspec.resource(1)
     #                    API Definition
     #=====================================================#
     [
-      :describe_alarms_for_metric
+      :describe_alarms_for_metric,
     ].each do |method|
       define_method(:method) do |*_args|
         raise "Unimplemented abstract method #{method} - internal error"

--- a/libraries/aws_conn.rb
+++ b/libraries/aws_conn.rb
@@ -17,6 +17,10 @@ class AWSConnection
   def sns_client
     @sns_client ||= Aws::SNS::Client.new
   end
+  
+  def cloudwatch_client
+    @cloudwatch_client ||= Aws::CloudWatch::Client.new
+  end
 
   def cloudwatch_logs_client
     @cloudwatch_logs_client ||= Aws::CloudWatchLogs::Client.new

--- a/libraries/aws_conn.rb
+++ b/libraries/aws_conn.rb
@@ -17,7 +17,7 @@ class AWSConnection
   def sns_client
     @sns_client ||= Aws::SNS::Client.new
   end
-  
+
   def cloudwatch_client
     @cloudwatch_client ||= Aws::CloudWatch::Client.new
   end

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -88,7 +88,7 @@ resource "aws_cloudwatch_log_metric_filter" "lmf_1" {
   log_group_name = "${aws_cloudwatch_log_group.lmf_lg_1.name}"
 
   metric_transformation {
-    name      = "${terraform.env}_KittehCount_1"
+    name      = "${terraform.env}_testmetric_1"
     namespace = "${terraform.env}_YourNamespace_1"
     value     = "1"
   }
@@ -100,10 +100,27 @@ resource "aws_cloudwatch_log_metric_filter" "lmf_2" {
   log_group_name = "${aws_cloudwatch_log_group.lmf_lg_2.name}"
 
   metric_transformation {
-    name      = "${terraform.env}_KittehCount_3"
+    name      = "${terraform.env}_testmetric_3"
     namespace = "${terraform.env}_YourNamespace_3"
     value     = "1"
   }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alarm_1" {
+  alarm_name                = "${terraform.env}-test-alarm-01"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "2"
+  metric_name               = "${terraform.env}_testmetric_1"
+  namespace                 = "${terraform.env}_YourNamespace_1"
+  period                    = "120"
+  statistic                 = "Average"
+  threshold                 = "80"
+  alarm_description         = "This metric is a test metric"
+  insufficient_data_actions = []
+}
+
+output "cloudwatch_alarm_01" {
+  value = "${terraform.env}-test-alarm-01"
 }
 
 output "lmf_1_name" {
@@ -115,7 +132,11 @@ output "lmf_2_name" {
 }
 
 output "lmf_1_metric_1_name" {
-  value = "${terraform.env}_KittehCount_1"
+  value = "${terraform.env}_testmetric_1"
+}
+
+output "lmf_1_metric_1_namespace" {
+  value = "${terraform.env}_YourNamespace_1"
 }
 
 output "lmf_lg_1_name" {
@@ -124,23 +145,6 @@ output "lmf_lg_1_name" {
 
 output "lmf_lg_2_name" {
   value = "${aws_cloudwatch_log_group.lmf_lg_2.name}"
-}
-
-resource "aws_cloudwatch_metric_alarm" "alarm_1" {
-  alarm_name                = "${terraform.env}-test-alarm-01"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
-  metric_name               = "CPUUtilization"
-  namespace                 = "AWS/EC2"
-  period                    = "120"
-  statistic                 = "Average"
-  threshold                 = "80"
-  alarm_description         = "This metric monitors ec2 cpu utilization"
-  insufficient_data_actions = []
-}
-
-output "cloudwatch_alarm_01" {
-  value = "${terraform.env}-test-alarm-01"
 }
 
 output "mfa_not_enabled_user" {

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -126,6 +126,23 @@ output "lmf_lg_2_name" {
   value = "${aws_cloudwatch_log_group.lmf_lg_2.name}"
 }
 
+resource "aws_cloudwatch_metric_alarm" "alarm_1" {
+  alarm_name                = "${terraform.env}-test-alarm-01"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "2"
+  metric_name               = "CPUUtilization"
+  namespace                 = "AWS/EC2"
+  period                    = "120"
+  statistic                 = "Average"
+  threshold                 = "80"
+  alarm_description         = "This metric monitors ec2 cpu utilization"
+  insufficient_data_actions = []
+}
+
+output "cloudwatch_alarm_01" {
+  value = "${terraform.env}-test-alarm-01"
+}
+
 output "mfa_not_enabled_user" {
   value = "${aws_iam_user.mfa_not_enabled_user.name}"
 }

--- a/test/integration/verify/controls/aws_cloudwatch_alarm.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_alarm.rb
@@ -3,10 +3,19 @@ alarm_01 = attribute(
   default: 'default.cloudwatch_alarm',
   description: 'Name of Cloudwatch Alarm')
 
-  # TODO: this is likely to be a multiple hit
+metric_01_name = attribute(
+  'lmf_1_metric_1_name',
+  default: 'default.lmf_1_metric_1_name',
+  description: 'A test metric name')
+
+metric_01_namespace = attribute(
+    'lmf_1_metric_1_namespace',
+    default: 'default.lmf_1_metric_1_namespace',
+    description: 'A test metric namespace')
+
   describe aws_cloudwatch_alarm(
-    metric_name: 'CPUUtilization',
-    metric_namespace: 'AWS/EC2',
+    metric_name: metric_01_name,
+    metric_namespace: metric_01_namespace,
   ) do
     it { should exist }
   end

--- a/test/integration/verify/controls/aws_cloudwatch_alarm.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_alarm.rb
@@ -13,6 +13,7 @@ metric_01_namespace = attribute(
     default: 'default.lmf_1_metric_1_namespace',
     description: 'A test metric namespace')
 
+control 'AWS Cloudwatch Alarm' do
   describe aws_cloudwatch_alarm(
     metric_name: metric_01_name,
     metric_namespace: metric_01_namespace,
@@ -26,3 +27,4 @@ metric_01_namespace = attribute(
   ) do
     it { should_not exist }
   end
+end

--- a/test/integration/verify/controls/aws_cloudwatch_alarm.rb
+++ b/test/integration/verify/controls/aws_cloudwatch_alarm.rb
@@ -1,0 +1,19 @@
+alarm_01 = attribute(
+  'cloudwatch_alarm_01',
+  default: 'default.cloudwatch_alarm',
+  description: 'Name of Cloudwatch Alarm')
+
+  # TODO: this is likely to be a multiple hit
+  describe aws_cloudwatch_alarm(
+    metric_name: 'CPUUtilization',
+    metric_namespace: 'AWS/EC2',
+  ) do
+    it { should exist }
+  end
+
+  describe aws_cloudwatch_alarm(
+    metric_name: 'NopeNope',
+    metric_namespace: 'Nope',
+  ) do
+    it { should_not exist }
+  end

--- a/test/unit/resources/aws_cloudwatch_alarm_test.rb
+++ b/test/unit/resources/aws_cloudwatch_alarm_test.rb
@@ -74,7 +74,35 @@ end
 #=============================================================================#
 #                                Properties
 #=============================================================================#
-  
+
+class AwsCWAConstructor < Minitest::Test
+  def setup
+    AwsCloudwatchAlarm::Backend.select(AwsMCWAB::Basic)
+  end
+
+  #---------------------------------------
+  #       alarm_actions
+  #---------------------------------------
+  def test_prop_actions_empty
+    alarm = AwsCloudwatchAlarm.new(
+      metric_name: 'metric-02',
+      metric_namespace: 'metric-namespace-02'
+    )
+    assert_kind_of Array, alarm.alarm_actions
+    assert_empty alarm.alarm_actions
+  end
+
+  def test_prop_actions_hit
+    alarm = AwsCloudwatchAlarm.new(
+      metric_name: 'metric-01',
+      metric_namespace: 'metric-namespace-01'
+    )
+    assert_kind_of Array, alarm.alarm_actions    
+    refute_empty alarm.alarm_actions
+    assert_kind_of String, alarm.alarm_actions.first
+  end  
+end
+
 #=============================================================================#
 #                               Test Fixtures
 #=============================================================================#
@@ -112,6 +140,13 @@ module AwsMCWAB
             alarm_name: 'alarm-03',
             metric_name: 'metric-02',
             namespace: 'metric-namespace-01',
+            statistic: 'SampleCount',
+            alarm_actions: []
+          }),
+          OpenStruct.new({
+            alarm_name: 'alarm-04',
+            metric_name: 'metric-02',
+            namespace: 'metric-namespace-02',
             statistic: 'SampleCount',
             alarm_actions: []
           }),

--- a/test/unit/resources/aws_cloudwatch_alarm_test.rb
+++ b/test/unit/resources/aws_cloudwatch_alarm_test.rb
@@ -1,0 +1,45 @@
+require 'ostruct'
+require 'helper'
+require 'aws_cloudwatch_alarm'
+
+# MCWAB = MockCloudwatchAlarmBackend
+# Abbreviation not used outside this file
+
+#=============================================================================#
+#                            Constructor Tests
+#=============================================================================#
+class AwsCWAConstructor < Minitest::Test
+  def setup
+    AwsCloudwatchAlarm::Backend.select(AwsMCWAB::Empty)
+  end
+
+  def test_constructor_some_args_required
+    assert_raises(ArgumentError) { AwsCloudwatchAlarm.new }
+  end
+
+  def test_constructor_accepts_known_resource_params_combos
+    [
+      { metric_name: 'some-val', metric_namespace: 'some-val' },
+    ].each do |combo|
+      AwsCloudwatchAlarm.new(combo)
+    end
+  end
+
+  def test_constructor_rejects_bad_resource_params_combos
+    [
+      { metric_name: 'some-val' },
+      { metric_namespace: 'some-val' },
+    ].each do |combo|
+      assert_raises(ArgumentError) { AwsCloudwatchAlarm.new(combo) }
+    end
+  end
+
+  def test_constructor_reject_unknown_resource_params
+    assert_raises(ArgumentError) { AwsCloudwatchAlarm.new(beep: 'boop') }    
+  end
+end
+
+module AwsMCWAB
+  class Empty < AwsCloudwatchAlarm::Backend
+  end
+end


### PR DESCRIPTION
This adds very basic support for a singular Cloudwatch Alarm resource, based on searching for alarms by metric name / namespace.  

Only one matcher implemented: `exists?`

Only one property implemented: `alarm_actions`.

Docs, unit tests, and integration tests included.