### PR TITLE
Add aws_sns_topic resource

### DIFF
--- a/docs/resources/aws_sns_topic.md
+++ b/docs/resources/aws_sns_topic.md
@@ -4,7 +4,7 @@ title: About the aws_sns_topic Resource
 
 # aws_sns_topic
 
-Use the `aws_sns_topic` InSpec audit resource to test properties of a single AWS Simple Notification Service Topic.  SNS topics are like channels for events; some resources will place items in the SNS topic, while other resources will _subscribe_ to receive notifications when new items have appeared.
+Use the `aws_sns_topic` InSpec audit resource to test properties of a single AWS Simple Notification Service Topic.  SNS topics are channels for related events.  AWS resources will place events in the SNS topic, while other AWS resources will _subscribe_ to receive notifications when new events have appeared.
 
 <br>
 
@@ -26,7 +26,7 @@ Use the `aws_sns_topic` InSpec audit resource to test properties of a single AWS
 
 ### ARN
 
-This resource expects a single parameter which should uniquely identify the SNS Topic, an ARN.  Amazon Resource Names for SNS have the format `arn:aws:sns:region:account-id:topicname`.  AWS requires you to use a fully-specified ARN when looking up an SNS topic; you cannot omit the account ID or use a wildcard region.
+This resource expects a single parameter that uniquely identifes the SNS Topic, an ARN. Amazon Resource Names for SNS topics have the format `arn:aws:sns:region:account-id:topicname`.  AWS requires a fully-specified ARN for looking up an SNS topic.  The account ID and region are required.  Wildcards are not permitted.
 
 See also the (AWS documentation on ARNs)[http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html].
 
@@ -50,7 +50,7 @@ Indicates that the ARN provided was found.  Use should_not to test for SNS topic
 
 ### confirmed_subscription_count
 
-An integer indicating how many subscriptions are currently active.
+An integer indicating the number of currently active subscriptions.
 
     # Make sure someone is listening
     describe aws_sns_topic('arn:aws:sns:*::my-topic-name') do

--- a/docs/resources/aws_sns_topic.md
+++ b/docs/resources/aws_sns_topic.md
@@ -1,0 +1,52 @@
+---
+title: About the aws_sns_topic Resource
+---
+
+# aws_sns_topic
+
+Use the `aws_sns_topic` InSpec audit resource to test properties of a single AWS Simple Notification Service Topic.  SNS topics are like channels for events; some resources will place items in the SNS topic, while other resources will _subscribe_ to receive notifications when new items have appeared.
+
+<br>
+
+## Syntax
+
+  # Ensure that a topic exists and has at least one subscriber
+  describe aws_sns_topic('arn:aws:sns:*::my-topic-name') do
+    it { should exist }
+    its('confirmed_subscriber_count') { should_not be_zero }
+  end
+
+## Resource Parameters
+
+### ARN
+
+This resource expects a single parameter which should uniquely identify the SNS Topic, an ARN.  Amazon Resource Names for SNS have the format `arn:aws:sns:region:account-id:topicname`.  Region may be replaced with '*' to match any region, and account-id may be omitted to use the account currently being accessed by InSpec.
+
+See also the (AWS documentation on ARNs)[http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html].
+
+## Matchers
+
+### exist
+
+Indicates that the ARN provided was found.  Use should_not to test for SNS topics that should not exist.
+
+    # Expect good news
+    describe aws_sns_topic('arn:aws:sns:*::good-news') do
+      it { should exist }
+    end
+
+    # No bad news allowed
+    describe aws_sns_topic('arn:aws:sns:*::bad-news') do
+      it { should_not exist }
+    end
+
+## Properties
+
+### confirmed_subscriber_count
+
+An integer indicating how many subscribers are currently active.
+
+    # Make sure someone is listening
+    describe aws_sns_topic('arn:aws:sns:*::my-topic-name') do
+      its('confirmed_subscriber_count') { should_not be_zero}
+    end

--- a/docs/resources/aws_sns_topic.md
+++ b/docs/resources/aws_sns_topic.md
@@ -10,11 +10,17 @@ Use the `aws_sns_topic` InSpec audit resource to test properties of a single AWS
 
 ## Syntax
 
-  # Ensure that a topic exists and has at least one subscriber
+  # Ensure that a topic exists and has at least one subscription
   describe aws_sns_topic('arn:aws:sns:*::my-topic-name') do
     it { should exist }
-    its('confirmed_subscriber_count') { should_not be_zero }
+    its('confirmed_subscription_count') { should_not be_zero }
   end
+
+  # You may also use has syntax to pass the ARN
+  describe aws_sns_topic(arn: 'arn:aws:sns:*::my-topic-name') do
+    it { should exist }
+  end
+  
 
 ## Resource Parameters
 
@@ -42,11 +48,11 @@ Indicates that the ARN provided was found.  Use should_not to test for SNS topic
 
 ## Properties
 
-### confirmed_subscriber_count
+### confirmed_subscription_count
 
-An integer indicating how many subscribers are currently active.
+An integer indicating how many subscriptions are currently active.
 
     # Make sure someone is listening
     describe aws_sns_topic('arn:aws:sns:*::my-topic-name') do
-      its('confirmed_subscriber_count') { should_not be_zero}
+      its('confirmed_subscription_count') { should_not be_zero}
     end

--- a/docs/resources/aws_sns_topic.md
+++ b/docs/resources/aws_sns_topic.md
@@ -26,7 +26,7 @@ Use the `aws_sns_topic` InSpec audit resource to test properties of a single AWS
 
 ### ARN
 
-This resource expects a single parameter which should uniquely identify the SNS Topic, an ARN.  Amazon Resource Names for SNS have the format `arn:aws:sns:region:account-id:topicname`.  Region may be replaced with '*' to match any region, and account-id may be omitted to use the account currently being accessed by InSpec.
+This resource expects a single parameter which should uniquely identify the SNS Topic, an ARN.  Amazon Resource Names for SNS have the format `arn:aws:sns:region:account-id:topicname`.  AWS requires you to use a fully-specified ARN when looking up an SNS topic; you cannot omit the account ID or use a wildcard region.
 
 See also the (AWS documentation on ARNs)[http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html].
 

--- a/libraries/aws_conn.rb
+++ b/libraries/aws_conn.rb
@@ -14,6 +14,10 @@ class AWSConnection
     Aws.config.update(opts)
   end
 
+  def sns_client 
+    @sns_client ||= Aws::SNS::Client.new
+  end
+
   def ec2_resource
     @ec2_resource ||= Aws::EC2::Resource.new
   end

--- a/libraries/aws_conn.rb
+++ b/libraries/aws_conn.rb
@@ -14,7 +14,7 @@ class AWSConnection
     Aws.config.update(opts)
   end
 
-  def sns_client 
+  def sns_client
     @sns_client ||= Aws::SNS::Client.new
   end
 

--- a/libraries/aws_sns_topic.rb
+++ b/libraries/aws_sns_topic.rb
@@ -1,0 +1,51 @@
+class AwsSnsTopic < Inspec.resource(1)
+  name 'aws_sns_topic'
+  desc 'Verifies settings for an SNS Topic'
+  example "
+    describe aws_sns_topic('arn:aws:sns:us-east-1:123456789012:some-topic') do
+      it { should exist }
+      its('confirmed_subscriber_count') { should_not be_zero }
+    end
+  "
+
+  def initialize(opts)
+  end
+
+  class Backend
+    #=====================================================#
+    #                    API Definition
+    #=====================================================#
+    [
+      :get_topic_attributes,
+    ].each do |method|
+      define_method(:method) do |*_args|
+        raise "Unimplemented abstract method #{method} - internal error"
+      end
+    end
+
+    #=====================================================#
+    #                 Concrete Implementation
+    #=====================================================#
+    # Uses the SDK API to really talk to AWS
+    class AwsClientApi < Backend
+      def get_topic_attributes(criteria)
+        raise 'TODO'
+      end
+    end
+
+    #=====================================================#
+    #                   Factory Interface
+    #=====================================================#
+    # TODO: move this to a mix-in
+    DEFAULT_BACKEND = AwsClientApi
+    @selected_backend = DEFAULT_BACKEND
+
+    def self.create
+      @selected_backend.new
+    end
+
+    def self.select(klass)
+      @selected_backend = klass
+    end
+  end  
+end

--- a/libraries/aws_sns_topic.rb
+++ b/libraries/aws_sns_topic.rb
@@ -29,7 +29,7 @@ class AwsSnsTopic < Inspec.resource(1)
     raw_params = { arn: raw_params } if raw_params.is_a?(String)
 
     # Remove all expected params from the raw param hash
-    validated_params = {}    
+    validated_params = {}
     [
       :arn,
     ].each do |expected_param|
@@ -51,15 +51,13 @@ class AwsSnsTopic < Inspec.resource(1)
   end
 
   def search
-    begin
-      aws_response = AwsSnsTopic::Backend.create.get_topic_attributes(topic_arn: @arn).attributes
-      @exists = true
-      
-      # The response has a plain hash with CamelCase plain string keys and string values
-      @confirmed_subscription_count = aws_response['SubscriptionsConfirmed'].to_i
-    rescue Aws::SNS::Errors::NotFound
-      @exists = false
-    end
+    aws_response = AwsSnsTopic::Backend.create.get_topic_attributes(topic_arn: @arn).attributes
+    @exists = true
+
+    # The response has a plain hash with CamelCase plain string keys and string values
+    @confirmed_subscription_count = aws_response['SubscriptionsConfirmed'].to_i
+  rescue Aws::SNS::Errors::NotFound
+    @exists = false
   end
 
   class Backend
@@ -98,5 +96,5 @@ class AwsSnsTopic < Inspec.resource(1)
     def self.select(klass)
       @selected_backend = klass
     end
-  end  
+  end
 end

--- a/libraries/aws_sns_topic.rb
+++ b/libraries/aws_sns_topic.rb
@@ -12,6 +12,12 @@ class AwsSnsTopic < Inspec.resource(1)
 
   def initialize(raw_params)
     validated_params = validate_params(raw_params)
+    @arn = validated_params[:arn]
+    search
+  end
+
+  def exists?
+    @exists
   end
 
   private
@@ -40,6 +46,16 @@ class AwsSnsTopic < Inspec.resource(1)
     end
 
     validated_params
+  end
+
+  def search
+    begin
+      aws_response = AwsSnsTopic::Backend.create.get_topic_attributes(arn: @arn).attributes
+      # The response has a plain hash with CamelCase plain string keys
+      @exists = true
+    rescue Aws::IAM::Errors::NoSuchEntity
+      @exists = false
+    end
   end
 
   class Backend

--- a/libraries/aws_sns_topic.rb
+++ b/libraries/aws_sns_topic.rb
@@ -8,7 +8,7 @@ class AwsSnsTopic < Inspec.resource(1)
     end
   "
 
-  attr_reader :arn
+  attr_reader :arn, :confirmed_subscription_count
 
   def initialize(raw_params)
     validated_params = validate_params(raw_params)
@@ -51,8 +51,10 @@ class AwsSnsTopic < Inspec.resource(1)
   def search
     begin
       aws_response = AwsSnsTopic::Backend.create.get_topic_attributes(arn: @arn).attributes
-      # The response has a plain hash with CamelCase plain string keys
       @exists = true
+      
+      # The response has a plain hash with CamelCase plain string keys
+      @confirmed_subscription_count = aws_response['SubscriptionsConfirmed']
     rescue Aws::IAM::Errors::NoSuchEntity
       @exists = false
     end

--- a/libraries/aws_sns_topic.rb
+++ b/libraries/aws_sns_topic.rb
@@ -4,7 +4,7 @@ class AwsSnsTopic < Inspec.resource(1)
   example "
     describe aws_sns_topic('arn:aws:sns:us-east-1:123456789012:some-topic') do
       it { should exist }
-      its('confirmed_subscriber_count') { should_not be_zero }
+      its('confirmed_subscription_count') { should_not be_zero }
     end
   "
 

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -96,3 +96,38 @@ output "example_ec2_id" {
 output "no_roles_ec2_id" {
   value = "${aws_instance.no_roles_instance.id}"
 }
+
+
+#===========================================================================#
+#                                   SNS
+#===========================================================================#
+
+# Test fixture: 
+# sns_test_topic_01 has one confirmed subscription
+# sns_test_topic_02 has no subscriptions
+
+resource "aws_sns_topic" "sns_test_topic_01" {
+  name = "${terraform.env}-test-topic-01"
+}
+
+output "sns_test_topic_01_arn" {
+  value = "${aws_sns_topic.sns_test_topic_01.arn}"
+}
+
+resource "aws_sqs_queue" "sqs_test_queue_01" {
+  name = "${terraform.env}-test-queue-01"
+}
+
+resource "aws_sns_topic_subscription" "sqs_test_queue_01_sub" {
+  topic_arn = "${aws_sns_topic.sns_test_topic_01.arn}"
+  protocol  = "sqs"
+  endpoint  = "${aws_sqs_queue.sqs_test_queue_01.arn}"
+}
+
+resource "aws_sns_topic" "sns_test_topic_02" {
+  name = "${terraform.env}-test-topic-02"
+}
+
+output "sns_test_topic_02_arn" {
+  value = "${aws_sns_topic.sns_test_topic_02.arn}"
+}

--- a/test/integration/verify/controls/aws_sns_topic.rb
+++ b/test/integration/verify/controls/aws_sns_topic.rb
@@ -1,0 +1,45 @@
+sns_topic_with_subscription_arn = attribute(
+  'sns_test_topic_01_arn',
+  default: 'default.sns_test_topic_01_arn',
+  description: 'ARN of an SNS topic with at least one subscription')
+
+sns_topic_with_no_subscriptions_arn = attribute(
+  'sns_test_topic_02_arn',
+  default: 'default.sns_test_topic_02_arn',
+  description: 'ARN of an SNS topic with no subscriptions')
+
+control 'SNS Topics' do
+  # Split the ARNs so we can test things
+  scheme, partition, service, region, account, topic = sns_topic_with_subscription_arn.split(':')
+  arn_prefix = [scheme, partition, service].join(':')
+
+  # Search miss
+  no_such_topic_arn = [arn_prefix, region, account, 'no-such-topic-for-realz'].join(':')
+  describe aws_sns_topic(no_such_topic_arn) do
+    it { should_not exist }
+  end
+
+  # Search hit, fully specified, has subscriptions
+  describe aws_sns_topic(sns_topic_with_subscription_arn) do
+    it { should exist }
+    its('confirmed_subscription_count') { should_not be_zero }
+  end
+
+  # Search hit, fully specified, has no subscriptions
+  describe aws_sns_topic(sns_topic_with_no_subscriptions_arn) do
+    it { should exist }
+    its('confirmed_subscription_count') { should be_zero }
+  end
+
+  # Cross-region search
+  all_region_arn = [arn_prefix, '*', account, topic].join(':')
+  describe aws_sns_topic(all_region_arn) do
+    it { should exist }
+  end
+
+  # Omit account (default to account used by InSpec connection)
+  omit_account_arn = [arn_prefix, region, '', topic].join(':')
+  describe aws_sns_topic(omit_account_arn) do
+    it { should exist }
+  end
+end

--- a/test/integration/verify/controls/aws_sns_topic.rb
+++ b/test/integration/verify/controls/aws_sns_topic.rb
@@ -31,15 +31,4 @@ control 'SNS Topics' do
     its('confirmed_subscription_count') { should be_zero }
   end
 
-  # Cross-region search
-  all_region_arn = [arn_prefix, '*', account, topic].join(':')
-  describe aws_sns_topic(all_region_arn) do
-    it { should exist }
-  end
-
-  # Omit account (default to account used by InSpec connection)
-  omit_account_arn = [arn_prefix, region, '', topic].join(':')
-  describe aws_sns_topic(omit_account_arn) do
-    it { should exist }
-  end
 end

--- a/test/unit/helper.rb
+++ b/test/unit/helper.rb
@@ -3,3 +3,6 @@ require 'minitest/unit'
 require 'minitest/pride'
 
 require 'inspec/resource'
+
+# Needed for exception classes, etc
+require 'aws-sdk'

--- a/test/unit/resources/aws_sns_topic_test.rb
+++ b/test/unit/resources/aws_sns_topic_test.rb
@@ -51,6 +51,25 @@ class AwsSnsTopicConstructorTest < Minitest::Test
   end
 end
 
+#=============================================================================#
+#                               Search / Recall
+#=============================================================================#
+class AwsSnsTopicRecallTest < Minitest::Test
+  # No setup here - each test needs to explicitly declare
+  # what they want from the backend.
+
+  def test_recall_no_match_is_no_exception
+    AwsSnsTopic::Backend.select(AwsMSNB::Miss)
+    topic = AwsSnsTopic.new('arn:aws:sns:us-east-1:123456789012:nope')
+    refute topic.exists?
+  end
+
+  def test_recall_match_single_result_works
+    AwsSnsTopic::Backend.select(AwsMSNB::NoSubscriptions)    
+    topic = AwsSnsTopic.new('arn:aws:sns:us-east-1:123456789012:does-not-matter')
+    assert topic.exists?
+  end
+end
 
 #=============================================================================#
 #                               Test Fixtures

--- a/test/unit/resources/aws_sns_topic_test.rb
+++ b/test/unit/resources/aws_sns_topic_test.rb
@@ -36,17 +36,10 @@ class AwsSnsTopicConstructorTest < Minitest::Test
       'arn::::::', # Too many colons
       'arn:aws::us-east-1:123456789012:some-topic', # Omits SNS service
       'arn::sns:us-east-1:123456789012:some-topic', # Omits partition
+      'arn:aws:sns:*:123456789012:some-topic',  # All-region - not permitted for lookup
+      'arn:aws:sns:us-east-1::some-topic',      # Default account - not permitted for lookup
     ].each do |example|
       assert_raises(ArgumentError) { AwsSnsTopic.new(arn: example) }
-    end
-  end
-
-  def test_constructor_accepts_arn_variants_as_hash
-    [
-      'arn:aws:sns:*:123456789012:some-topic',  # All-region
-      'arn:aws:sns:us-east-1::some-topic', # Default account
-    ].each do |variant|
-      AwsSnsTopic.new(arn: variant)
     end
   end
 end
@@ -103,7 +96,7 @@ module AwsMSNB
 
   class Miss < AwsSnsTopic::Backend
     def get_topic_attributes(criteria)
-      raise Aws::IAM::Errors::NoSuchEntity.new("No SNS topic for #{criteria[:topic_arn]}", 'Nope')
+      raise Aws::SNS::Errors::NotFound.new("No SNS topic for #{criteria[:topic_arn]}", 'Nope')
     end
   end
 

--- a/test/unit/resources/aws_sns_topic_test.rb
+++ b/test/unit/resources/aws_sns_topic_test.rb
@@ -1,0 +1,90 @@
+require 'ostruct'
+require 'helper'
+require 'aws_sns_topic'
+
+# MSNB = MockSnsBackend
+# Abbreviation not used outside this file
+
+#=============================================================================#
+#                            Constructor Tests
+#=============================================================================#
+class AwsSnsTopicConstructorTest < Minitest::Test
+  def setup
+    AwsSnsTopic::Backend.select(AwsMSNB::NoSubscriptions)
+  end
+
+  def test_constructor_some_args_required
+    assert_raises(ArgumentError) { AwsSnsTopic.new }
+  end
+
+  def test_constructor_accepts_scalar_arn
+    AwsSnsTopic.new('arn:aws:sns:us-east-1:123456789012:some-topic')
+  end
+
+  def test_constructor_accepts_arn_as_hash
+    AwsSnsTopic.new(arn: 'arn:aws:sns:us-east-1:123456789012:some-topic')    
+  end
+  
+  def test_constructor_rejects_unrecognized_resource_params
+    assert_raises(ArgumentError) { AwsSnsTopic.new(beep: 'boop') }
+  end
+    
+  def test_constructor_rejects_non_arn_formats
+    [
+      'not-even-like-an-arn',
+      'arn:::::', # Empty
+      'arn::::::', # Too many colons
+      'arn:aws::us-east-1:123456789012:some-topic', # Omits SNS service
+      'arn::sns:us-east-1:123456789012:some-topic', # Omits partition
+    ].each do |example|
+      assert_raises(ArgumentError) { AwsSnsTopic.new(arn: example) }
+    end
+  end
+
+  def test_constructor_accepts_arn_variants_as_hash
+    [
+      'arn:aws:sns:*:123456789012:some-topic',  # All-region
+      'arn:aws:sns:us-east-1::some-topic', # Default account
+    ].each do |variant|
+      AwsSnsTopic.new(arn: variant)
+    end
+  end
+end
+
+
+#=============================================================================#
+#                               Test Fixtures
+#=============================================================================#
+
+module AwsMSNB
+
+  class Miss < AwsSnsTopic::Backend
+    def get_topic_attributes(criteria)
+      raise Aws::IAM::Errors::NoSuchEntity.new("No SNS topic for #{criteria[:topic_arn]}", 'Nope')
+    end
+  end
+
+  class NoSubscriptions < AwsSnsTopic::Backend
+    def get_topic_attributes(_criteria)
+      OpenStruct.new({
+        attributes: { # Note that this is a plain hash, odd for AWS SDK
+          # Many other attributes available, see 
+          # http://docs.aws.amazon.com/sdkforruby/api/Aws/SNS/Types/GetTopicAttributesResponse.html
+          "SubscriptionsConfirmed" => 0
+        }
+      })
+    end
+  end
+
+  class OneSubscription < AwsSnsTopic::Backend
+    def get_topic_attributes(_criteria)
+      OpenStruct.new({
+        attributes: { # Note that this is a plain hash, odd for AWS SDK
+          # Many other attributes available, see 
+          # http://docs.aws.amazon.com/sdkforruby/api/Aws/SNS/Types/GetTopicAttributesResponse.html
+          "SubscriptionsConfirmed" => 1
+        }
+      })
+    end
+  end
+end

--- a/test/unit/resources/aws_sns_topic_test.rb
+++ b/test/unit/resources/aws_sns_topic_test.rb
@@ -72,6 +72,30 @@ class AwsSnsTopicRecallTest < Minitest::Test
 end
 
 #=============================================================================#
+#                                Properties
+#=============================================================================#
+
+class AwsSnsTopicPropertiesTest < Minitest::Test
+  # No setup here - each test needs to explicitly declare
+  # what they want from the backend.
+
+  #---------------------------------------
+  #       confirmed_subscription_count
+  #---------------------------------------
+  def test_prop_conf_sub_count_zero
+    AwsSnsTopic::Backend.select(AwsMSNB::NoSubscriptions)
+    topic = AwsSnsTopic.new('arn:aws:sns:us-east-1:123456789012:does-not-matter')
+    assert_equal(0, topic.confirmed_subscription_count)
+  end
+
+  def test_prop_conf_sub_count_zero
+    AwsSnsTopic::Backend.select(AwsMSNB::OneSubscription)
+    topic = AwsSnsTopic.new('arn:aws:sns:us-east-1:123456789012:does-not-matter')
+    assert_equal(1, topic.confirmed_subscription_count)
+  end
+end
+
+#=============================================================================#
 #                               Test Fixtures
 #=============================================================================#
 


### PR DESCRIPTION
Adds a very simple SNS topic resource, implemented using the API's get_topic_attributes call.

It requires a full ARN as a resource parameter; you may pass it as a plain string, or as a hash with the `arn:` key.

There is currently only one property, `confirmed_subscriptions_count`.  

Normal set of integration tests, unit tests, and docs are included.