### PR TITLE
Add policy attachment properties to user resource

### DIFF
--- a/libraries/aws_iam_user.rb
+++ b/libraries/aws_iam_user.rb
@@ -37,11 +37,11 @@ class AwsIamUser < Inspec.resource(1)
   end
 
   def has_policies?
-    @user[:has_policies?]
+    @aws_user_details_provider.has_policies?
   end
 
   def has_attached_policies?
-    @user[:has_attached_policies?]
+    @aws_user_details_provider.has_attached_policies?
   end
 
   def access_keys

--- a/libraries/aws_iam_user.rb
+++ b/libraries/aws_iam_user.rb
@@ -36,6 +36,10 @@ class AwsIamUser < Inspec.resource(1)
     @aws_user_details_provider.has_console_password?
   end
 
+  def has_policies?
+    @user[:has_policies?]
+  end
+
   def access_keys
     @aws_user_details_provider.access_keys.map { |access_key|
       @access_key_factory.create_access_key(access_key)

--- a/libraries/aws_iam_user.rb
+++ b/libraries/aws_iam_user.rb
@@ -40,6 +40,10 @@ class AwsIamUser < Inspec.resource(1)
     @user[:has_policies?]
   end
 
+  def has_attached_policies?
+    @user[:has_attached_policies?]
+  end
+
   def access_keys
     @aws_user_details_provider.access_keys.map { |access_key|
       @access_key_factory.create_access_key(access_key)

--- a/libraries/aws_iam_user_details_provider.rb
+++ b/libraries/aws_iam_user_details_provider.rb
@@ -28,6 +28,14 @@ module AwsIam
     def access_keys
       @aws_user.access_keys
     end
+
+    def has_policies?
+      !@aws_user.policies.first.nil?
+    end
+
+    def has_attached_policies?
+      !@aws_user.attached_policies.first.nil?
+    end
   end
 
   class UserDetailsProviderInitializer

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -74,6 +74,29 @@ resource "aws_iam_user_policy" "mfa_not_enabled_policy" {
 EOF
 }
 
+resource "aws_iam_policy" "attached_policy" {
+  name        = "attached-policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Deny",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user_policy_attachment" "test-attachment" {
+  user       = "${aws_iam_user.console_password_enabled_user.name}"
+  policy_arn = "${aws_iam_policy.attached_policy.arn}"
+}
+
 resource "aws_iam_user" "console_password_enabled_user" {
     name = "${terraform.env}.console_password_enabled_user"
     force_destroy = true

--- a/test/integration/build/aws.tf
+++ b/test/integration/build/aws.tf
@@ -54,6 +54,26 @@ resource "aws_iam_user" "mfa_not_enabled_user" {
     name = "${terraform.env}.mfa_not_enabled_user"
 }
 
+resource "aws_iam_user_policy" "mfa_not_enabled_policy" {
+  name = "test"
+  user = "${aws_iam_user.mfa_not_enabled_user.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Deny",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_iam_user" "console_password_enabled_user" {
     name = "${terraform.env}.console_password_enabled_user"
     force_destroy = true

--- a/test/integration/verify/controls/aws_iam_user.rb
+++ b/test/integration/verify/controls/aws_iam_user.rb
@@ -17,11 +17,13 @@ describe aws_iam_user(name: mfa_not_enabled_user) do
   it { should_not have_mfa_enabled }
   it { should_not have_console_password }
   it { should have_policies }
+  it { should_not have_attached_policies }
 end
 
 describe aws_iam_user(name: console_password_enabled_user) do
   it { should have_console_password }
   it { should_not have_policies }
+  it { should have_attached_policies }
 end
 
 aws_iam_user(name: access_key_user).access_keys.each { |access_key|

--- a/test/integration/verify/controls/aws_iam_user.rb
+++ b/test/integration/verify/controls/aws_iam_user.rb
@@ -16,10 +16,12 @@ access_key_user = attribute(
 describe aws_iam_user(name: mfa_not_enabled_user) do
   it { should_not have_mfa_enabled }
   it { should_not have_console_password }
+  it { should have_policies }
 end
 
 describe aws_iam_user(name: console_password_enabled_user) do
   it { should have_console_password }
+  it { should_not have_policies }
 end
 
 aws_iam_user(name: access_key_user).access_keys.each { |access_key|

--- a/test/unit/resources/aws_iam_user_details_provider_test.rb
+++ b/test/unit/resources/aws_iam_user_details_provider_test.rb
@@ -82,4 +82,36 @@ class AwsIamUserDetailsProviderTest < Minitest::Test
     provider = AwsIam::UserDetailsProvider.new(@mock_iam_resource_user)
     assert_equal [access_key], provider.access_keys
   end
+
+  def test_policies_returns_policy
+    policy = Object.new
+
+    @mock_iam_resource_user.expect :policies, [policy]
+
+    provider = AwsIam::UserDetailsProvider.new(@mock_iam_resource_user)
+    assert provider.has_policies?
+  end
+  
+  def test_policies_returns_no_policy
+    @mock_iam_resource_user.expect :policies, []
+
+    provider = AwsIam::UserDetailsProvider.new(@mock_iam_resource_user)
+    refute provider.has_policies?
+  end
+  
+  def test_policies_returns_attached_policies
+    policy = Object.new
+
+    @mock_iam_resource_user.expect :attached_policies, [policy]
+
+    provider = AwsIam::UserDetailsProvider.new(@mock_iam_resource_user)
+    assert provider.has_attached_policies?
+  end
+  
+  def test_policies_returns_no_attached_policies
+    @mock_iam_resource_user.expect :attached_policies, []
+
+    provider = AwsIam::UserDetailsProvider.new(@mock_iam_resource_user)
+    refute provider.has_attached_policies?
+  end
 end

--- a/test/unit/resources/aws_iam_user_details_provider_test.rb
+++ b/test/unit/resources/aws_iam_user_details_provider_test.rb
@@ -91,14 +91,14 @@ class AwsIamUserDetailsProviderTest < Minitest::Test
     provider = AwsIam::UserDetailsProvider.new(@mock_iam_resource_user)
     assert provider.has_policies?
   end
-  
+
   def test_policies_returns_no_policy
     @mock_iam_resource_user.expect :policies, []
 
     provider = AwsIam::UserDetailsProvider.new(@mock_iam_resource_user)
     refute provider.has_policies?
   end
-  
+
   def test_policies_returns_attached_policies
     policy = Object.new
 
@@ -107,7 +107,7 @@ class AwsIamUserDetailsProviderTest < Minitest::Test
     provider = AwsIam::UserDetailsProvider.new(@mock_iam_resource_user)
     assert provider.has_attached_policies?
   end
-  
+
   def test_policies_returns_no_attached_policies
     @mock_iam_resource_user.expect :attached_policies, []
 

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -107,16 +107,15 @@ class AwsIamUserTest < Minitest::Test
   end
 
   def test_that_has_policies_returns_true
-    @mock_user_provider.expect(
-      :user,
-      { has_policies?: true },
-      [Username],
-    )
+    @mock_user_provider.expect :user, @mock_user, [Username]
+    @mock_dets_provider.expect :has_policies?, true
+    @mock_dets_prov_ini.expect :create, @mock_dets_provider, [@mock_user]
 
     assert (
       AwsIamUser.new(
-        { name: Username },
+        @mock_user,
         @mock_user_provider,
+        @mock_dets_prov_ini,
       ).has_policies?
     )
 

--- a/test/unit/resources/aws_iam_user_test.rb
+++ b/test/unit/resources/aws_iam_user_test.rb
@@ -106,6 +106,22 @@ class AwsIamUserTest < Minitest::Test
     mock_access_key_factory.verify
   end
 
+  def test_that_has_policies_returns_true
+    @mock_user_provider.expect(
+      :user,
+      { has_policies?: true },
+      [Username],
+    )
+
+    assert (
+      AwsIamUser.new(
+        { name: Username },
+        @mock_user_provider,
+      ).has_policies?
+    )
+
+  end
+
   def test_to_s
     test_user = { name: Username, has_mfa_enabled?: true }
     @mock_user_provider.expect :user, test_user, [Username]


### PR DESCRIPTION
Adding `has_policies?` and `has_attached_policies?`.   Fixes #74.