### PR TITLE
Add method to determine if hardware mfa is enabled for the root account

### DIFF
--- a/libraries/aws_iam_root_user.rb
+++ b/libraries/aws_iam_root_user.rb
@@ -20,6 +20,16 @@ class AwsIamRootUser < Inspec.resource(1)
     summary_account['AccountMFAEnabled'] == 1
   end
 
+  def has_hardware_mfa_enabled?
+    virtual_mfa_devices.each do |device|
+      if %r{arn:aws:iam::\d{12}:mfa\/root-account-mfa-device} =~
+        device['serial_number']
+        return false
+      end
+    end
+    true
+  end
+
   def to_s
     'AWS Root-User'
   end
@@ -28,5 +38,9 @@ class AwsIamRootUser < Inspec.resource(1)
 
   def summary_account
     @summary_account ||= @client.get_account_summary.summary_map
+  end
+
+  def virtual_mfa_devices
+    @client.list_virtual_mfa_devices.virtual_mfa_devices
   end
 end

--- a/libraries/aws_iam_root_user.rb
+++ b/libraries/aws_iam_root_user.rb
@@ -20,14 +20,14 @@ class AwsIamRootUser < Inspec.resource(1)
     summary_account['AccountMFAEnabled'] == 1
   end
 
-  def has_hardware_mfa_enabled?
+  def has_virtual_mfa_devices?
     virtual_mfa_devices.each do |device|
       if %r{arn:aws:iam::\d{12}:mfa\/root-account-mfa-device} =~
         device['serial_number']
-        return false
+        return true
       end
     end
-    true
+    false
   end
 
   def to_s

--- a/test/unit/resources/aws_iam_root_user_test.rb
+++ b/test/unit/resources/aws_iam_root_user_test.rb
@@ -37,4 +37,38 @@ class AwsIamRootUserTest < Minitest::Test
 
     assert_equal false, AwsIamRootUser.new(@mock_conn).has_mfa_enabled?
   end
+
+  def test_has_hardware_mfa_devices_returns_true_when_no_virtual_mfa_for_root
+    test_virtual_mfa_devices = OpenStruct.new(
+      virtual_mfa_devices: [
+        { 'serial_number' => 'arn:aws:iam::123456789012:mfa/TestUser' },
+        { 'serial_number' => 'arn:aws:iam::123456789012:mfa/TestUser' },
+      ],
+    )
+    @mock_client.expect :list_virtual_mfa_devices, test_virtual_mfa_devices
+
+    assert_equal true, AwsIamRootUser.new(@mock_conn).has_hardware_mfa_enabled?
+  end
+
+  def test_has_hardware_mfa_devices_returns_false_when_virtual_mfa_for_root
+    test_virtual_mfa_devices = OpenStruct.new(
+      virtual_mfa_devices: [
+        { 'serial_number' => 'arn:aws:iam::123456789012:mfa/' },
+        { 'serial_number' =>
+          'arn:aws:iam::123456789012:mfa/root-account-mfa-device' },
+      ],
+    )
+    @mock_client.expect :list_virtual_mfa_devices, test_virtual_mfa_devices
+
+    assert_equal false, AwsIamRootUser.new(@mock_conn).has_hardware_mfa_enabled?
+  end
+
+  def test_has_hardware_mfa_devices_returns_true_when_no_virtual_mfa_devices
+    test_virtual_mfa_devices = OpenStruct.new(
+      virtual_mfa_devices: [],
+    )
+    @mock_client.expect :list_virtual_mfa_devices, test_virtual_mfa_devices
+
+    assert_equal true, AwsIamRootUser.new(@mock_conn).has_hardware_mfa_enabled?
+  end
 end

--- a/test/unit/resources/aws_iam_root_user_test.rb
+++ b/test/unit/resources/aws_iam_root_user_test.rb
@@ -38,7 +38,7 @@ class AwsIamRootUserTest < Minitest::Test
     assert_equal false, AwsIamRootUser.new(@mock_conn).has_mfa_enabled?
   end
 
-  def test_has_virtual_mfa_devices_returns_true_when_no_virtual_mfa_for_root
+  def test_has_virtual_mfa_devices_returns_false_when_no_virtual_mfa_for_root
     test_virtual_mfa_devices = OpenStruct.new(
       virtual_mfa_devices: [
         { 'serial_number' => 'arn:aws:iam::123456789012:mfa/TestUser' },
@@ -50,7 +50,7 @@ class AwsIamRootUserTest < Minitest::Test
     assert_equal false, AwsIamRootUser.new(@mock_conn).has_virtual_mfa_devices?
   end
 
-  def test_has_virtual_mfa_devices_returns_false_when_virtual_mfa_for_root
+  def test_has_virtual_mfa_devices_returns_true_when_virtual_mfa_for_root
     test_virtual_mfa_devices = OpenStruct.new(
       virtual_mfa_devices: [
         { 'serial_number' => 'arn:aws:iam::123456789012:mfa/' },
@@ -63,7 +63,7 @@ class AwsIamRootUserTest < Minitest::Test
     assert_equal true, AwsIamRootUser.new(@mock_conn).has_virtual_mfa_devices?
   end
 
-  def test_has_virtual_mfa_devices_returns_true_when_no_virtual_mfa_devices
+  def test_has_virtual_mfa_devices_returns_false_when_no_virtual_mfa_devices
     test_virtual_mfa_devices = OpenStruct.new(
       virtual_mfa_devices: [],
     )

--- a/test/unit/resources/aws_iam_root_user_test.rb
+++ b/test/unit/resources/aws_iam_root_user_test.rb
@@ -38,7 +38,7 @@ class AwsIamRootUserTest < Minitest::Test
     assert_equal false, AwsIamRootUser.new(@mock_conn).has_mfa_enabled?
   end
 
-  def test_has_hardware_mfa_devices_returns_true_when_no_virtual_mfa_for_root
+  def test_has_virtual_mfa_devices_returns_true_when_no_virtual_mfa_for_root
     test_virtual_mfa_devices = OpenStruct.new(
       virtual_mfa_devices: [
         { 'serial_number' => 'arn:aws:iam::123456789012:mfa/TestUser' },
@@ -47,10 +47,10 @@ class AwsIamRootUserTest < Minitest::Test
     )
     @mock_client.expect :list_virtual_mfa_devices, test_virtual_mfa_devices
 
-    assert_equal true, AwsIamRootUser.new(@mock_conn).has_hardware_mfa_enabled?
+    assert_equal false, AwsIamRootUser.new(@mock_conn).has_virtual_mfa_devices?
   end
 
-  def test_has_hardware_mfa_devices_returns_false_when_virtual_mfa_for_root
+  def test_has_virtual_mfa_devices_returns_false_when_virtual_mfa_for_root
     test_virtual_mfa_devices = OpenStruct.new(
       virtual_mfa_devices: [
         { 'serial_number' => 'arn:aws:iam::123456789012:mfa/' },
@@ -60,15 +60,15 @@ class AwsIamRootUserTest < Minitest::Test
     )
     @mock_client.expect :list_virtual_mfa_devices, test_virtual_mfa_devices
 
-    assert_equal false, AwsIamRootUser.new(@mock_conn).has_hardware_mfa_enabled?
+    assert_equal true, AwsIamRootUser.new(@mock_conn).has_virtual_mfa_devices?
   end
 
-  def test_has_hardware_mfa_devices_returns_true_when_no_virtual_mfa_devices
+  def test_has_virtual_mfa_devices_returns_true_when_no_virtual_mfa_devices
     test_virtual_mfa_devices = OpenStruct.new(
       virtual_mfa_devices: [],
     )
     @mock_client.expect :list_virtual_mfa_devices, test_virtual_mfa_devices
 
-    assert_equal true, AwsIamRootUser.new(@mock_conn).has_hardware_mfa_enabled?
+    assert_equal false, AwsIamRootUser.new(@mock_conn).has_virtual_mfa_devices?
   end
 end


### PR DESCRIPTION
Signed-off-by: sfreeman <Steffanie.Freeman@d2l.com>

To fulfill recommendation 1.14 - Issue #73 
We don't think it's possible to run an integration test here with Terraform, but if you have any ideas let us know!