### PR TITLE
Update rubocop 0.44.0 -> 0.51.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 ---
 AllCops:
+  TargetRubyVersion: 2.3
   Exclude:
   - Gemfile
   - Rakefile
@@ -7,31 +8,76 @@ AllCops:
   - 'examples/**/*'
   - 'vendor/**/*'
   - 'lib/bundles/inspec-init/templates/**/*'
-Documentation:
-  Enabled: false
+  - 'www/tutorial/**/*'
 AlignParameters:
   Enabled: true
-Encoding:
-  Enabled: true
+BlockDelimiters:
+  Enabled: false
+Documentation:
+  Enabled: false
+EmptyLinesAroundBlockBody:
+  Enabled: false
+FrozenStringLiteralComment:
+  Enabled: false
 HashSyntax:
   Enabled: true
 LineLength:
   Enabled: false
-EmptyLinesAroundBlockBody:
+Layout/AlignHash:
+  Enabled: false
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+Layout/EndOfLine:
+  Enabled: true
+  EnforcedStyle: lf
+Layout/SpaceAroundOperators:
   Enabled: false
 MethodLength:
   Max: 40
-NumericLiterals:
-  MinDigits: 10
-Metrics/LineLength:
-  Enabled: true
-  Max: 100
+Metrics/AbcSize:
+  Max: 33
+Metrics/BlockLength:
+  Max: 50
 Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/PerceivedComplexity:
   Max: 11
-Metrics/AbcSize:
-  Max: 33
+Naming/FileName:
+  Enabled: false
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+Naming/PredicateName:
+  Enabled: false
+NumericLiterals:
+  MinDigits: 10
+Security/YAMLLoad:
+  Enabled: false
+Style/AndOr:
+  Enabled: false
+Style/BracesAroundHashParameters:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/ConditionalAssignment:
+  Enabled: false
+Style/EmptyMethod:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/MethodMissing:
+  Enabled: false
+Style/MultilineIfModifier:
+  Enabled: false
+Style/NegatedIf:
+  Enabled: false
+Style/Not:
+  Enabled: false
+Style/NumericLiteralPrefix:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%':  '{}'
@@ -43,35 +89,11 @@ Style/PercentLiteralDelimiters:
     '%w': '{}'
     '%W': ()
     '%x': ()
-Style/AlignHash:
+Style/SymbolArray:
   Enabled: false
-Style/IndentHash:
-  Enabled: false
-Style/PredicateName:
-  Enabled: false
-Style/ClassAndModuleChildren:
-  Enabled: false
-Style/ConditionalAssignment:
-  Enabled: false
-Style/BracesAroundHashParameters:
-  Enabled: false
-Style/AndOr:
-  Enabled: false
-Style/Not:
-  Enabled: false
-Style/FileName:
-  Enabled: false
-Style/TrailingCommaInLiteral:
-  EnforcedStyleForMultiline: comma
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
-Style/NegatedIf:
-  Enabled: false
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
 Style/UnlessElse:
-  Enabled: false
-BlockDelimiters:
-  Enabled: false
-Style/SpaceAroundOperators:
-  Enabled: false
-Style/IfUnlessModifier:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rake'
 gem 'inspec', '~> 1'
-gem 'rubocop', '~> 0.44.0'
+gem 'rubocop', '~> 0.51.0'
 gem 'highline', '~> 1.6.0'
 gem 'aws-sdk', '~> 2'
 gem 'nokogiri'

--- a/libraries/aws_ec2_instance.rb
+++ b/libraries/aws_ec2_instance.rb
@@ -49,7 +49,7 @@ class AwsEc2Instance < Inspec.resource(1)
 
   # returns the instance state
   def state
-    instance.state.name if instance
+    instance&.state&.name
   end
 
   # helper methods for each state

--- a/libraries/aws_iam_access_keys.rb
+++ b/libraries/aws_iam_access_keys.rb
@@ -36,7 +36,7 @@ class AwsIamAccessKeys < Inspec.resource(1)
             'by 16 letters or numbers'
     end
 
-    criteria.keys.each do |criterion|
+    criteria.each_key do |criterion|
       unless VALUED_CRITERIA.include?(criterion) # rubocop:disable Style/Next
         raise 'Unrecognized filter criterion for aws_iam_access_keys, ' \
           "'#{criterion}'.  Valid choices are " \


### PR DESCRIPTION
This PR updates Rubocop to the latest, copies in the config file from inspec core, and makes a few adjustments in the codebase to accommodate some sensible rules.

Fixes #126 
