### PR TITLE
Add created_with_user filter criteria to aws_iam_access_keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,3 @@ gem 'minitest', '5.10.1'
 group :tools do
   gem 'github_changelog_generator', '~> 1.12.0'
 end
-
-# Added at 2017-12-06 10:20:41 -0500 by cwolfe:
-gem "byebug", "~> 9.1"

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,6 @@ gem 'minitest', '5.10.1'
 group :tools do
   gem 'github_changelog_generator', '~> 1.12.0'
 end
+
+# Added at 2017-12-06 10:20:41 -0500 by cwolfe:
+gem "byebug", "~> 9.1"

--- a/docs/resources/aws_iam_access_keys.md
+++ b/docs/resources/aws_iam_access_keys.md
@@ -158,7 +158,7 @@ Searches for access keys owned by the named user. Each user may have zero, one, 
 
 The date at which the user was created.
 
-    # User have to be a week old to have a key
+    # Users have to be a week old to have a key
     describe aws_iam_access_keys.where { user_created_date > Date.now - 7 }
       it { should_not exist }
     end

--- a/docs/resources/aws_iam_access_keys.md
+++ b/docs/resources/aws_iam_access_keys.md
@@ -145,6 +145,15 @@ Searches for access keys owned by the named user. Each user may have zero, one, 
       it { should exist }
     end
 
+### user_created_date
+
+The date at which the user was created.
+
+    # User have to be a week old to have a key
+    describe aws_iam_access_keys.where { user_created_date > Date.now - 7 }
+      it { should_not exist }
+    end
+
 ## Properties
 
 ### access_key_ids

--- a/docs/resources/aws_iam_access_keys.md
+++ b/docs/resources/aws_iam_access_keys.md
@@ -91,6 +91,15 @@ An integer, representing how old the access key is.
       it { should_not exist }
     end
 
+### created_with_user
+
+A true / false value indicating if the Access Key was likely created at the same time as the user, by checking if the difference between created_date and user_created_date is less than 1 hour.
+
+    # Do not automatically create keys for users
+    describe aws_iam_access_keys.where { created_with_user } do
+      it { should_not exist }
+    end
+
 ### ever_used
 
 A true / false value indicating if the Access Key has ever been used, based on the last_used_date. See also: `never_used`.

--- a/libraries/aws_iam_access_keys.rb
+++ b/libraries/aws_iam_access_keys.rb
@@ -55,6 +55,7 @@ class AwsIamAccessKeys < Inspec.resource(1)
         .add(:access_key_ids, field: :access_key_id)
         .add(:created_date, field: :created_date)
         .add(:created_days_ago, field: :created_days_ago)
+        .add(:created_with_user, field: :created_with_user)
         .add(:created_hours_ago, field: :created_hours_ago)
         .add(:usernames, field: :username)
         .add(:active, field: :active)
@@ -87,7 +88,7 @@ class AwsIamAccessKeys < Inspec.resource(1)
     class AwsUserIterator < AccessKeyProvider
       def fetch(criteria)
         iam_client = AWSConnection.new.iam_client
-
+        
         user_details = {}
         if criteria.key?(:username)
           begin
@@ -136,7 +137,8 @@ class AwsIamAccessKeys < Inspec.resource(1)
         key_info[:created_hours_ago] = ((Time.now - key_info[:create_date]) / (60*60)).to_i
         key_info[:created_days_ago] = (key_info[:created_hours_ago] / 24).to_i
         key_info[:user_created_date] = user_details[:create_date]
-        
+        key_info[:created_with_user] = (key_info[:create_date] - key_info[:user_created_date]).abs < 1.0/24.0
+
         # Last used is a separate API call
         iam_client = AWSConnection.new.iam_client
         last_used =

--- a/libraries/aws_iam_access_keys.rb
+++ b/libraries/aws_iam_access_keys.rb
@@ -66,7 +66,7 @@ class AwsIamAccessKeys < Inspec.resource(1)
         .add(:ever_used,           field: :ever_used)
         .add(:never_used,          field: :never_used)
         .add(:user_created_date,   field: :user_created_date)
-        filter.connect(self, :access_key_data)
+  filter.connect(self, :access_key_data)
 
   def access_key_data
     @table
@@ -88,13 +88,13 @@ class AwsIamAccessKeys < Inspec.resource(1)
     class AwsUserIterator < AccessKeyProvider
       def fetch(criteria)
         iam_client = AWSConnection.new.iam_client
-        
+
         user_details = {}
         if criteria.key?(:username)
           begin
             user_details[criteria[:username]] = iam_client.get_user(user_name: criteria[:username]).user
           rescue Aws::IAM::Errors::NoSuchEntity # rubocop:disable Lint/HandleExceptions
-            # Swallow - a miss on search results should return an empty table            
+            # Swallow - a miss on search results should return an empty table
           end
         else
           # TODO: pagination check and resume

--- a/test/integration/verify/controls/aws_iam_access_key.rb
+++ b/test/integration/verify/controls/aws_iam_access_key.rb
@@ -42,6 +42,9 @@ control 'IAM Access Keys' do
                    .where { last_used_days_ago > 0 } do
     it { should exist }    
   end
+  describe all_keys.where { created_with_user } do
+    it { should exist }
+  end
 end
 
 control 'AKS3' do

--- a/test/unit/resources/aws_iam_access_keys_test.rb
+++ b/test/unit/resources/aws_iam_access_keys_test.rb
@@ -64,7 +64,7 @@ end
 
 class AwsIamAccessKeysFilterCriteriaTest < Minitest::Test
   def setup
-    # Here we always want no rseults.
+    # Here we always want no results.
     AwsIamAccessKeys::AccessKeyProvider.select(AlwaysEmptyMAKP)
     @valued_criteria = {
       username: 'bob',
@@ -262,6 +262,20 @@ class AwsIamAccessKeysPropertiesTest < Minitest::Test
     assert_equal(1, block_filtered.entries.count)
     assert block_filtered.access_key_ids.first.end_with?('BOB')
   end
+
+  #----------------------------------------------------------#
+  #                    user_created_date                     #
+  #----------------------------------------------------------#
+  def test_property_user_created_date
+    assert_kind_of(DateTime, @all_basic.entries.first.user_created_date)
+    arg_filtered = @all_basic.where(user_created_date: DateTime.parse('2017-10-21T17:58:00Z'))
+    assert_equal(1, arg_filtered.entries.count)
+    assert arg_filtered.access_key_ids.first.end_with?('SALLY')
+
+    block_filtered = @all_basic.where { user_created_date.saturday? }
+    assert_equal(1, block_filtered.entries.count)
+    assert block_filtered.access_key_ids.first.end_with?('SALLY')
+  end
 end
 #==========================================================#
 #                 Mock Support Classes                     #
@@ -294,6 +308,7 @@ class BasicMAKP < AwsIamAccessKeys::AccessKeyProvider
         last_used_hours_ago: nil,
         ever_used: false,
         never_used: true,
+        user_created_date: DateTime.parse('2017-10-27T17:58:00Z'),
       },
       {
         username: 'sally',
@@ -310,6 +325,7 @@ class BasicMAKP < AwsIamAccessKeys::AccessKeyProvider
         last_used_hours_ago: 102,
         ever_used: true,
         never_used: false,
+        user_created_date: DateTime.parse('2017-10-21T17:58:00Z'),        
       },
       {
         username: 'robin',
@@ -326,6 +342,7 @@ class BasicMAKP < AwsIamAccessKeys::AccessKeyProvider
         last_used_hours_ago: 5,
         ever_used: true,
         never_used: false,
+        user_created_date: DateTime.parse('2017-10-31T17:58:00Z'),        
       },
     ]
   end

--- a/test/unit/resources/aws_iam_access_keys_test.rb
+++ b/test/unit/resources/aws_iam_access_keys_test.rb
@@ -170,6 +170,21 @@ class AwsIamAccessKeysPropertiesTest < Minitest::Test
   end
 
   #----------------------------------------------------------#
+  #                     created_with_user                    #
+  #----------------------------------------------------------#
+  def test_property_created_with_user
+    assert_kind_of(TrueClass, @all_basic.entries[0].created_with_user)
+    assert_kind_of(FalseClass, @all_basic.entries[1].created_with_user)
+
+    arg_filtered = @all_basic.where(created_with_user: true)
+    assert_equal(2, arg_filtered.entries.count)
+    assert arg_filtered.access_key_ids.first.end_with?('BOB')
+
+    block_filtered = @all_basic.where { created_with_user }
+    assert_equal(2, block_filtered.entries.count)
+  end
+
+  #----------------------------------------------------------#
   #                    active / inactive                     #
   #----------------------------------------------------------#
   def test_property_active
@@ -300,6 +315,7 @@ class BasicMAKP < AwsIamAccessKeys::AccessKeyProvider
         created_date: DateTime.parse('2017-10-27T17:58:00Z'),
         created_days_ago: 4,
         created_hours_ago: 102,
+        created_with_user: true,
         status: 'Active',
         active: true,
         inactive: false,
@@ -317,6 +333,7 @@ class BasicMAKP < AwsIamAccessKeys::AccessKeyProvider
         created_date: DateTime.parse('2017-10-22T17:58:00Z'),
         created_days_ago: 9,
         created_hours_ago: 222,
+        created_with_user: false,        
         status: 'Active',
         active: true,
         inactive: false,
@@ -334,6 +351,7 @@ class BasicMAKP < AwsIamAccessKeys::AccessKeyProvider
         created_date: DateTime.parse('2017-10-31T17:58:00Z'),
         created_days_ago: 1,
         created_hours_ago: 12,
+        created_with_user: true,        
         status: 'Inactive',
         active: false,
         inactive: true,
@@ -342,7 +360,7 @@ class BasicMAKP < AwsIamAccessKeys::AccessKeyProvider
         last_used_hours_ago: 5,
         ever_used: true,
         never_used: false,
-        user_created_date: DateTime.parse('2017-10-31T17:58:00Z'),        
+        user_created_date: DateTime.parse('2017-10-31T17:58:00Z'),  
       },
     ]
   end


### PR DESCRIPTION
This PR adds two filter criteria (things you can put in a 'where'), to assist in implementing controls such as those needed by CIS AWS Benchmark recommendation 1.23.

`user_created_date` - The DateTime at which the user associated with the key was created.

`created_with_user` - True/False; True if `user_created_date` and `create_date` are within an hour of each other.