### PR TITLE
Add skeleton of aws_iam_role

### DIFF
--- a/docs/resources/aws_iam_role.md
+++ b/docs/resources/aws_iam_role.md
@@ -15,9 +15,6 @@ Use the `aws_iam_role` InSpec audit resource to test properties of a single IAM 
     it { should exist }
   end
 
-  # Obtain the AssumeRole Policy as a decoded hash
-  policy_info = aws_iam_role(other-role).assume_role_policy  
-
 ## Resource Parameters
 
 ### role_name
@@ -55,7 +52,3 @@ A textual description of the IAM Role.
     describe aws_iam_role('my-role') do
       its('description') { should be('Our most important Role')}
     end
-
-### assume_role_policy
-
-A Ruby Hash created from the URL-encoded JSON policy document.  This structure contains information in the IAM Policy language that controls who is allows to utilize this role.

--- a/docs/resources/aws_iam_role.md
+++ b/docs/resources/aws_iam_role.md
@@ -1,0 +1,61 @@
+---
+title: About the aws_iam_role Resource
+---
+
+# aws_iam_role
+
+Use the `aws_iam_role` InSpec audit resource to test properties of a single IAM Role.  A Role is a collection of permissions that may be temporarily assumed by a user, EC2 Instance, Lambda Function, or certain other resources.
+
+<br>
+
+## Syntax
+
+  # Ensure that a certain role exists by name
+  describe aws_iam_role('my-role') do
+    it { should exist }
+  end
+
+  # Obtain the AssumeRole Policy as a decoded hash
+  policy_info = aws_iam_role(other-role).assume_role_policy  
+
+## Resource Parameters
+
+### role_name
+
+This resource expects a single parameter that uniquely identifes the IAM Role, the Role Name.  You may pass it as a string, or as the value in a hash:
+
+  describe aws_iam_role('my-role') do
+    it { should exist }
+  end
+  # Same
+  describe aws_iam_role(role_name: 'my-role') do
+    it { should exist }
+  end
+
+## Matchers
+
+### exist
+
+Indicates that the Role Name provided was found.  Use should_not to test for IAM Roles that should not exist.
+
+    describe aws_iam_role('should-be-there') do
+      it { should exist }
+    end
+
+    describe aws_iam_role('should-not-be-there') do
+      it { should_not exist }
+    end
+
+## Properties
+
+### description
+
+A textual description of the IAM Role.
+
+    describe aws_iam_role('my-role') do
+      its('description') { should be('Our most important Role')}
+    end
+
+### assume_role_policy
+
+A Ruby Hash created from the URL-encoded JSON policy document.  This structure contains information in the IAM Policy language that controls who is allows to utilize this role.

--- a/libraries/aws_iam_role.rb
+++ b/libraries/aws_iam_role.rb
@@ -1,0 +1,39 @@
+class AwsIamRole < Inspec.resource(1)
+  name 'aws_iam_role'
+  desc 'Verifies settings for an IAM Role'
+  example "
+    describe aws_iam_role('my-role') do
+      it { should exist }
+    end
+  "
+
+  include AwsResourceMixin
+  attr_reader :role_name
+
+  private
+
+  def validate_params(raw_params)
+    validated_params = check_resource_param_names(
+      raw_params: raw_params,
+      allowed_params: [:role_name],
+      allowed_scalar_name: :role_name,
+      allowed_scalar_type: String,
+    )
+    if validated_params.empty?
+      raise ArgumentError, 'You must provide a role_name to aws_iam_role.'
+    end
+    validated_params
+  end
+
+  def fetch_from_aws
+    # TODO
+  end
+
+  # Uses the SDK API to really talk to AWS
+  class Backend
+    class AwsClientApi
+      BackendFactory.set_default_backend(self)
+      # TODO
+    end
+  end
+end

--- a/libraries/aws_iam_role.rb
+++ b/libraries/aws_iam_role.rb
@@ -8,7 +8,7 @@ class AwsIamRole < Inspec.resource(1)
   "
 
   include AwsResourceMixin
-  attr_reader :role_name
+  attr_reader :role_name, :description
 
   private
 
@@ -34,6 +34,7 @@ class AwsIamRole < Inspec.resource(1)
       return
     end
     @exists = true
+    @description = role_info.role.description
   end
 
   # Uses the SDK API to really talk to AWS

--- a/libraries/aws_iam_role.rb
+++ b/libraries/aws_iam_role.rb
@@ -26,14 +26,23 @@ class AwsIamRole < Inspec.resource(1)
   end
 
   def fetch_from_aws
-    # TODO
+    role_info = nil
+    begin
+      role_info = AwsIamRole::BackendFactory.create.get_role(role_name: role_name)
+    rescue Aws::IAM::Errors::NoSuchEntity
+      @exists = false
+      return
+    end
+    @exists = true
   end
 
   # Uses the SDK API to really talk to AWS
   class Backend
     class AwsClientApi
       BackendFactory.set_default_backend(self)
-      # TODO
+      def get_role(query)
+        AWSConnection.new.iam_client.get_role(query)
+      end
     end
   end
 end

--- a/test/integration/verify/controls/aws_iam_role.rb
+++ b/test/integration/verify/controls/aws_iam_role.rb
@@ -1,0 +1,6 @@
+control 'AWS IAM Role search for default AWS role' do
+  # Every AWS account comes with this one by default
+  describe aws_iam_role('AWSServiceRoleForOrganizations') do
+    it { should exist }
+  end
+end

--- a/test/unit/resources/aws_iam_role_test.rb
+++ b/test/unit/resources/aws_iam_role_test.rb
@@ -30,6 +30,24 @@ class AwsIamRoleConstructorTest < Minitest::Test
 end
 
 #=============================================================================#
+#                               Search / Recall
+#=============================================================================#
+class AwsIamRoleRecallTest < Minitest::Test
+  # No setup here - each test needs to explicitly declare
+  # what they want from the backend.
+
+  def test_recall_no_match_is_no_exception
+    AwsIamRole::BackendFactory.select(AwsMIRB::Miss)
+    refute AwsIamRole.new('nonesuch').exists?
+  end
+
+  def test_recall_match_single_result_works
+    AwsIamRole::BackendFactory.select(AwsMIRB::Basic)
+    assert AwsIamRole.new('alpha').exists?
+  end
+end
+
+#=============================================================================#
 #                               Test Fixtures
 #=============================================================================#
 module AwsMIRB
@@ -42,7 +60,7 @@ module AwsMIRB
   class Basic
     def get_role(query)
       fixtures = {
-        alpha => OpenStruct.new({
+        'alpha' => OpenStruct.new({
           role_name: 'alpha',
         }),
       }
@@ -50,7 +68,7 @@ module AwsMIRB
         raise Aws::IAM::Errors::NoSuchEntity.new('Nope', 'Nope')
       end
       OpenStruct.new({
-        role => fixtures[query[:role_name]]
+        role: fixtures[query[:role_name]]
       })
     end
   end

--- a/test/unit/resources/aws_iam_role_test.rb
+++ b/test/unit/resources/aws_iam_role_test.rb
@@ -47,6 +47,29 @@ class AwsIamRoleRecallTest < Minitest::Test
   end
 end
 
+
+#=============================================================================#
+#                                Properties
+#=============================================================================#
+
+class AwsIamRolePropertiesTest < Minitest::Test
+  def setup
+    AwsIamRole::BackendFactory.select(AwsMIRB::Basic)
+  end
+
+  #---------------------------------------
+  #       description
+  #---------------------------------------
+  def test_property_description
+    assert_equal('alpha role', AwsIamRole.new('alpha').description)
+  end
+
+  def test_prop_conf_sub_count_zero
+    assert_empty(AwsIamRole.new('beta').description)    
+  end
+end
+
+
 #=============================================================================#
 #                               Test Fixtures
 #=============================================================================#
@@ -62,6 +85,11 @@ module AwsMIRB
       fixtures = {
         'alpha' => OpenStruct.new({
           role_name: 'alpha',
+          description: 'alpha role',
+        }),
+        'beta' => OpenStruct.new({
+          role_name: 'beta',
+          description: '',
         }),
       }
       unless fixtures.key?(query[:role_name])

--- a/test/unit/resources/aws_iam_role_test.rb
+++ b/test/unit/resources/aws_iam_role_test.rb
@@ -1,0 +1,57 @@
+require 'helper'
+require 'aws_iam_role'
+
+# MIRB = MockIamRoleBackend
+# Abbreviation not used outside this file
+
+#=============================================================================#
+#                            Constructor Tests
+#=============================================================================#
+class AwsIamRoleConstructorTest < Minitest::Test
+  def setup
+    AwsIamRole::BackendFactory.select(AwsMIRB::Basic)
+  end
+
+  def test_constructor_some_args_required
+    assert_raises(ArgumentError) { AwsIamRole.new }
+  end
+
+  def test_constructor_accepts_scalar_role_name
+    AwsIamRole.new('alpha')
+  end
+
+  def test_constructor_accepts_role_name_as_hash
+    AwsIamRole.new(role_name: 'alpha')    
+  end
+  
+  def test_constructor_rejects_unrecognized_resource_params
+    assert_raises(ArgumentError) { AwsIamRole.new(beep: 'boop') }
+  end
+end
+
+#=============================================================================#
+#                               Test Fixtures
+#=============================================================================#
+module AwsMIRB
+  class Miss
+    def get_role(query)
+      raise Aws::IAM::Errors::NoSuchEntity.new('Nope', 'Nope')
+    end
+  end
+
+  class Basic
+    def get_role(query)
+      fixtures = {
+        alpha => OpenStruct.new({
+          role_name: 'alpha',
+        }),
+      }
+      unless fixtures.key?(query[:role_name])
+        raise Aws::IAM::Errors::NoSuchEntity.new('Nope', 'Nope')
+      end
+      OpenStruct.new({
+        role => fixtures[query[:role_name]]
+      })
+    end
+  end
+end


### PR DESCRIPTION
Adds a very basic aws_iam_role resource, allowing search by name and having a description resource.

Fixes #132 