### PR TITLE
Skeleton aws_ec2_security_group resource

### DIFF
--- a/docs/resources/aws_ec2_security_group.md
+++ b/docs/resources/aws_ec2_security_group.md
@@ -1,0 +1,144 @@
+---
+title: About the aws_ec2_security_group Resource
+---
+
+# aws_ec2_security_group
+
+Use the `aws_ec2_security_group` InSpec audit resource to test detailed properties of an individual Security Group (SG).
+
+SGs are a networking construct which contain ingress and egress rules for network communications.  SGs may be attached to EC2 instances, as well as certain other AWS resources.  Along with Network Access Control Lists, SGs are one of the two main mechanisms of enforcing network-level security.
+
+<br>
+
+## Syntax
+
+An `aws_ec2_security_group` resource block uses resource parameters to search for a Security Group, and then tests that Security Group.  If no SGs match, no error is raised, but the `exists` matcher will return `false` and all properties will be `nil`.  If more than one SG matches (due to vague search parameters), an error is raised.
+
+    # Ensure you have a security group with a certain ID
+    # This is "safe" - SG IDs are unique within an account
+    describe aws_ec2_security_group('sg-12345678') do
+      it { should exist }
+    end
+
+    # Ensure you have a security group with a certain ID
+    # This uses hash syntax
+    describe aws_ec2_security_group(id: 'sg-12345678') do
+      it { should exist }
+    end
+
+<br>
+
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+As this is the initial release of `aws_ec2_security_group`, its limited functionality precludes examples.
+
+<br>
+
+## Resource Parameters
+
+This InSpec resource accepts the following parameters, which are used to search for the Security Group.
+
+### id, group_id
+
+The Security Group ID of the Security Group.  This is of the format `sg-` followed by 8 hexadecimal characters.  The ID is unique within your AWS account; using ID ensures that you will never match more than one SG.  The ID is also the default resource parameter, so you may omit the hash syntax.
+
+    # Using Hash syntax 
+    describe aws_ec2_security_group(id: 'sg-12345678') do
+      it { should exist }
+    end
+
+    # group_id is an alias for id
+    describe aws_ec2_security_group(group_id: 'sg-12345678') do
+      it { should exist }
+    end
+
+    # Or omit hash syntax, rely on it being the default parameter
+    describe aws_ec2_security_group('sg-12345678') do
+      it { should exist }
+    end
+
+### group_name
+
+The string Name of the Security Group.  Every VPC has a security group named 'default'.  Names are unique within a VPC, but not within an AWS account.
+
+    # Get default security group for a certain VPC
+    describe aws_ec2_security_group(group_name: 'default', vpc_id: vpc_id: 'vpc-12345678') do
+      it { should exist }
+    end
+
+    # This will throw an error if there is a 'backend' SG in more than one VPC.
+    describe aws_ec2_security_group(group_name: 'backend') do
+      it { should exist }
+    end
+
+### vpc_id
+
+A string identifying the VPC which contains the security group.  Since VPCs commonly contain many SGs, you should add additional parameters to ensure you find exactly one SG.
+
+    # This will error if there is more than the default SG
+    describe aws_ec2_security_group(vpc_id: 'vpc-12345678') do
+      it { should exist }    
+    end
+
+<br>
+
+## Matchers
+
+### exists
+
+The control will pass if the specified SG was found.  Use should_not if you want to verify that the specified SG does not exist.
+
+    # You will always have at least one SG, the VPC default SG
+    describe aws_ec2_security_group(group_name: 'default')
+      it { should exist }
+    end   
+
+    # Make sure we don't have any security groups with the name 'nogood'
+    describe aws_ec2_security_group(group_name: 'nogood')
+      it { should_not exist }
+    end 
+
+## Filter Criteri
+
+## Properties
+
+### group_id
+
+Provides the Security Group ID.
+
+    # Inspect the group ID of the default group
+    describe aws_ec2_security_group(group_name: 'default', vpc_id: vpc_id: 'vpc-12345678') do
+      its('group_id') { should cmp 'sg-12345678' }
+    end
+
+    # Store the group ID in a Ruby variable for use elsewhere
+    sg_id = aws_ec2_security_group(group_name: 'default', vpc_id: vpc_id: 'vpc-12345678').group_id
+
+### group_name
+
+A String reflecting the name that was given to the SG at creation time.
+
+    # Inspect the group name of a particular group
+    describe aws_ec2_security_group('sg-12345678') do
+      its('group_name') { should cmp 'my_group' }
+    end
+
+### description
+
+A String reflecting the human-meaningful description that was given to the SG at creation time.
+
+    # Require a description of a particular group
+    describe aws_ec2_security_group('sg-12345678') do
+      its('description') { should_not be_empty }
+    end
+
+### vpc_id
+
+A String in the format 'vpc-' followed by 8 hexadecimal characters reflecting VPC that contains the security group.
+
+    # Inspec the VPC ID of a particular group
+    describe aws_ec2_security_group('sg-12345678') do
+      its('vpc_id') { should cmp 'vpc-12345678' }
+    end

--- a/docs/resources/aws_ec2_security_group.md
+++ b/docs/resources/aws_ec2_security_group.md
@@ -100,8 +100,6 @@ The control will pass if the specified SG was found.  Use should_not if you want
       it { should_not exist }
     end 
 
-## Filter Criteri
-
 ## Properties
 
 ### group_id

--- a/libraries/aws_ec2_security_group.rb
+++ b/libraries/aws_ec2_security_group.rb
@@ -1,0 +1,59 @@
+class AwsEc2SecurityGroup < Inspec.resource(1)
+  name 'aws_ec2_security_group'
+  desc 'Verifies settings for an individual AWS Security Group.'
+  example '
+    describe aws_ec2_security_group("sg-12345678") do
+      it { should exist }
+    end
+  '
+
+  include AwsResourceMixin
+  attr_reader :group_id
+
+  def to_s
+    'EC2 Security Group'
+  end
+
+  private
+
+  def validate_params(raw_params)
+    recognized_params = check_resource_param_names(
+      raw_params: raw_params,
+      allowed_params: [:id, :group_id, :group_name, :vpc_id],
+      allowed_scalar_name: :group_id,
+      allowed_scalar_type: String,
+    )
+
+    # id is an alias for group_id
+    recognized_params[:group_id] = recognized_params.delete(:id) if recognized_params.key?(:id)
+
+    if recognized_params.key?(:group_id) && recognized_params[:group_id] !~ /^sg\-[0-9a-f]{8}/
+      raise ArgumentError, 'aws_ec2_security_group security group ID must be in the format "sg-" followed by 8 hexadecimal characters.'
+    end
+
+    if recognized_params.key?(:vpc_id) && recognized_params[:vpc_id] !~ /^vpc\-[0-9a-f]{8}/
+      raise ArgumentError, 'aws_ec2_security_group VPC ID must be in the format "vpc-" followed by 8 hexadecimal characters.'
+    end
+
+    validated_params = recognized_params
+
+    if validated_params.empty?
+      raise ArgumentError, 'You must provide parameters to aws_ec2_security_group, such as group_name, group_id, or vpc_id.g_group.'
+    end
+    validated_params
+  end
+
+  def fetch_from_aws
+    # TODO
+  end
+
+  class Backend
+    class AwsClientApi < Backend
+      AwsEc2SecurityGroup::BackendFactory.set_default_backend self
+
+      def describe_security_groups(query)
+        AWSConnection.new.ec2_client.describe_security_groups(query)
+      end
+    end
+  end
+end

--- a/libraries/aws_ec2_security_group.rb
+++ b/libraries/aws_ec2_security_group.rb
@@ -56,10 +56,12 @@ class AwsEc2SecurityGroup < Inspec.resource(1)
     ].each do |criterion_name|
       val = instance_variable_get("@#{criterion_name}".to_sym)
       next if val.nil?
-      filters.push({
-                     name: criterion_name.to_s.tr('_', '-'),
-        values: [val],
-                   })
+      filters.push(
+        {
+          name: criterion_name.to_s.tr('_', '-'),
+          values: [val],
+        },
+      )
     end
     dsg_response = backend.describe_security_groups(filters: filters)
 

--- a/libraries/aws_ec2_security_group.rb
+++ b/libraries/aws_ec2_security_group.rb
@@ -57,7 +57,7 @@ class AwsEc2SecurityGroup < Inspec.resource(1)
       val = instance_variable_get("@#{criterion_name}".to_sym)
       unless val.nil?
         filters.push({
-          name: criterion_name.to_s.tr('-','_'),
+          name: criterion_name.to_s.tr('_','-'),
           values: [val],
         })
       end

--- a/libraries/aws_ec2_security_group.rb
+++ b/libraries/aws_ec2_security_group.rb
@@ -50,17 +50,16 @@ class AwsEc2SecurityGroup < Inspec.resource(1)
     filters = []
     [
       :description,
-      :group_id, 
-      :group_name, 
+      :group_id,
+      :group_name,
       :vpc_id,
     ].each do |criterion_name|
       val = instance_variable_get("@#{criterion_name}".to_sym)
-      unless val.nil?
-        filters.push({
-          name: criterion_name.to_s.tr('_','-'),
-          values: [val],
-        })
-      end
+      next if val.nil?
+      filters.push({
+                     name: criterion_name.to_s.tr('_', '-'),
+        values: [val],
+                   })
     end
     dsg_response = backend.describe_security_groups(filters: filters)
 
@@ -70,11 +69,10 @@ class AwsEc2SecurityGroup < Inspec.resource(1)
     end
 
     @exists = true
-    @description   = dsg_response.security_groups[0].description
+    @description = dsg_response.security_groups[0].description
     @group_id   = dsg_response.security_groups[0].group_id
     @group_name = dsg_response.security_groups[0].group_name
     @vpc_id     = dsg_response.security_groups[0].vpc_id
-    
   end
 
   class Backend

--- a/test/integration/build/ec2.tf
+++ b/test/integration/build/ec2.tf
@@ -19,3 +19,15 @@ output "ec2_security_group_default_vpc_id" {
 output "ec2_security_group_default_group_id" {
   value = "${data.aws_security_group.default.id}"
 }
+
+# Create a security group with a known description 
+# in the default VPC
+resource "aws_security_group" "alpha" {
+  name        = "alpha"
+  description = "SG alpha"
+  vpc_id      = "${data.aws_vpc.default.id}"
+}
+
+output "ec2_security_group_alpha_group_id" {
+  value = "${aws_security_group.alpha.id}"
+}

--- a/test/integration/verify/controls/aws_ec2_security_group.rb
+++ b/test/integration/verify/controls/aws_ec2_security_group.rb
@@ -1,0 +1,41 @@
+fixtures = {}
+[
+  'ec2_security_group_default_vpc_id',
+  'ec2_security_group_default_group_id',
+  'ec2_security_group_alpha_group_id',
+].each do |fixture_name|
+  fixtures[fixture_name] = attribute(
+    fixture_name,
+    default: "default.#{fixture_name}",
+    description: 'See ../build/ec2.tf',
+  )
+end
+
+control "aws_ec2_security_group recall of default VPC" do
+
+  describe aws_ec2_security_group(fixtures['ec2_security_group_default_group_id']) do
+    it { should exist }
+  end
+
+  describe aws_ec2_security_group(group_name: 'default', vpc_id: fixtures['ec2_security_group_default_vpc_id']) do
+    it { should exist }
+  end
+
+  describe aws_ec2_security_group(group_name: 'no-such-security-group') do
+    it { should_not exist }
+  end
+end
+
+control "aws_ec2_security_group properties" do
+  # You should be able to find the default security group's ID.
+  describe aws_ec2_security_group(fixtures['ec2_security_group_default_group_id']) do
+    its('group_id') { should cmp fixtures['ec2_security_group_default_group_id'] }
+  end
+
+  describe aws_ec2_security_group(fixtures['ec2_security_group_alpha_group_id']) do
+    its('group_name') { should cmp 'alpha' }
+    its('vpc_id') { should cmp  fixtures['ec2_security_group_default_vpc_id'] }
+    its('description') { should cmp 'SG alpha' }
+  end
+
+end

--- a/test/unit/resources/aws_ec2_security_group_test.rb
+++ b/test/unit/resources/aws_ec2_security_group_test.rb
@@ -1,0 +1,62 @@
+require 'ostruct'
+require 'helper'
+require 'aws_ec2_security_group'
+
+# MESGSB = MockEc2SecurityGroupSingleBackend
+# Abbreviation not used outside this file
+
+#=============================================================================#
+#                            Constructor Tests
+#=============================================================================#
+class AwsESGSConstructor < Minitest::Test
+  def setup
+    AwsEc2SecurityGroup::BackendFactory.select(AwsMESGSB::Empty)
+  end
+  
+  def test_constructor_no_args_raises
+    assert_raises(ArgumentError) { AwsEc2SecurityGroup.new }
+  end
+
+  def test_constructor_accept_scalar_param
+    AwsEc2SecurityGroup.new('sg-12345678')
+  end
+
+  def test_constructor_expected_well_formed_args
+    {
+      id: 'sg-1234abcd',
+      group_id: 'sg-1234abcd',
+      vpc_id: 'vpc-1234abcd',
+      group_name: 'some-group',
+    }.each do |param, value| 
+      AwsEc2SecurityGroup.new(param => value)
+    end
+  end
+
+  def test_constructor_reject_malformed_args
+    {
+      id: 'sg-xyz-123',
+      group_id: '1234abcd',
+      vpc_id: 'vpc_1234abcd',
+    }.each do |param, value| 
+      assert_raises(ArgumentError) { AwsEc2SecurityGroup.new(param => value) }
+    end
+  end
+
+  def test_constructor_reject_unknown_resource_params
+    assert_raises(ArgumentError) { AwsEc2SecurityGroup.new(beep: 'boop') }
+  end
+end
+
+#=============================================================================#
+#                               Test Fixtures
+#=============================================================================#
+
+module AwsMESGSB
+  class Empty < AwsEc2SecurityGroup::Backend
+    def describe_security_groups(_query)
+      OpenStruct.new({
+        security_groups: [],
+      })
+    end
+  end
+end

--- a/test/unit/resources/aws_ec2_security_group_test.rb
+++ b/test/unit/resources/aws_ec2_security_group_test.rb
@@ -70,6 +70,12 @@ class AwsESGSConstructor < Minitest::Test
     assert_equal('vpc-aaaabbbb', AwsEc2SecurityGroup.new('sg-aaaabbbb').vpc_id)
     assert_nil(AwsEc2SecurityGroup.new('sg-87654321').vpc_id)
   end
+
+  def test_property_description
+    assert_equal('Awesome Group', AwsEc2SecurityGroup.new('sg-12345678').description)
+    assert_nil(AwsEc2SecurityGroup.new('sg-87654321').description)
+  end
+
 end
 
 #=============================================================================#
@@ -89,11 +95,13 @@ module AwsMESGSB
     def describe_security_groups(query)
       fixtures = [
         OpenStruct.new({
+          description: 'Some Group',
           group_id: 'sg-aaaabbbb',
           group_name: 'alpha',
           vpc_id: 'vpc-aaaabbbb',
         }),
         OpenStruct.new({
+          description: 'Awesome Group',          
           group_id: 'sg-12345678',
           group_name: 'beta',
           vpc_id: 'vpc-12345678',
@@ -102,7 +110,7 @@ module AwsMESGSB
 
       selected = fixtures.select do |sg|
         query[:filters].all? do |filter|
-          filter[:values].include?(sg[filter[:name].to_sym])
+          filter[:values].include?(sg[filter[:name].tr('-','_')])
         end
       end
 


### PR DESCRIPTION
This is a simple singular resource, to complement the plural resource provided on #135 .  

Performs search by security group ID, group name, or VPC ID.  Exposes those along with description as properties.

Docs, unit tests, and integration tests included.