### PR TITLE
Silence some test warnings

### DIFF
--- a/libraries/aws_ec2_security_group.rb
+++ b/libraries/aws_ec2_security_group.rb
@@ -54,7 +54,9 @@ class AwsEc2SecurityGroup < Inspec.resource(1)
       :group_name,
       :vpc_id,
     ].each do |criterion_name|
-      val = instance_variable_get("@#{criterion_name}".to_sym)
+      instance_var = "@#{criterion_name}".to_sym
+      next unless instance_variable_defined?(instance_var)
+      val = instance_variable_get(instance_var)
       next if val.nil?
       filters.push(
         {

--- a/test/unit/resources/aws_ec2_security_group_test.rb
+++ b/test/unit/resources/aws_ec2_security_group_test.rb
@@ -51,7 +51,7 @@ end
 #                               Properties
 #=============================================================================#
 
-class AwsESGSConstructor < Minitest::Test
+class AwsESGSProperties < Minitest::Test
   def setup
     AwsEc2SecurityGroup::BackendFactory.select(AwsMESGSB::Basic)
   end

--- a/test/unit/resources/aws_sns_topic_test.rb
+++ b/test/unit/resources/aws_sns_topic_test.rb
@@ -80,7 +80,7 @@ class AwsSnsTopicPropertiesTest < Minitest::Test
     assert_equal(0, topic.confirmed_subscription_count)
   end
 
-  def test_prop_conf_sub_count_zero
+  def test_prop_conf_sub_count_one
     AwsSnsTopic::BackendFactory.select(AwsMSNB::OneSubscription)
     topic = AwsSnsTopic.new('arn:aws:sns:us-east-1:123456789012:does-not-matter')
     assert_equal(1, topic.confirmed_subscription_count)


### PR DESCRIPTION
Recent work on sns_topic and ec2_security_group introduced some spurious warnings when running the full unit test suite.  

After this PR, I only see warnings coming from dependent gems (and also inspec-core).