### PR TITLE
fixed resource dependency issue

### DIFF
--- a/libraries/aws_cloudwatch_alarm.rb
+++ b/libraries/aws_cloudwatch_alarm.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 class AwsCloudwatchAlarm < Inspec.resource(1)
   name 'aws_cloudwatch_alarm'
   desc <<-EOD

--- a/libraries/aws_cloudwatch_log_metric_filter.rb
+++ b/libraries/aws_cloudwatch_log_metric_filter.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 class AwsCloudwatchLogMetricFilter < Inspec.resource(1)
   name 'aws_cloudwatch_log_metric_filter'
   desc 'Verifies individual Cloudwatch Log Metric Filters'

--- a/libraries/aws_ec2_instance.rb
+++ b/libraries/aws_ec2_instance.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 # author: Christoph Hartmann
 class AwsEc2Instance < Inspec.resource(1)
   name 'aws_ec2_instance'

--- a/libraries/aws_ec2_security_group.rb
+++ b/libraries/aws_ec2_security_group.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 class AwsEc2SecurityGroup < Inspec.resource(1)
   name 'aws_ec2_security_group'
   desc 'Verifies settings for an individual AWS Security Group.'

--- a/libraries/aws_ec2_security_groups.rb
+++ b/libraries/aws_ec2_security_groups.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 class AwsEc2SecurityGroups < Inspec.resource(1)
   name 'aws_ec2_security_groups'
   desc 'Verifies settings for AWS Security Groups in bulk'

--- a/libraries/aws_iam_access_key.rb
+++ b/libraries/aws_iam_access_key.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 # author: Chris Redekop
 class AwsIamAccessKey < Inspec.resource(1)
   name 'aws_iam_access_key'

--- a/libraries/aws_iam_access_keys.rb
+++ b/libraries/aws_iam_access_keys.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 class AwsIamAccessKeys < Inspec.resource(1)
   name 'aws_iam_access_keys'
   desc 'Verifies settings for AWS IAM Access Keys in bulk'

--- a/libraries/aws_iam_password_policy.rb
+++ b/libraries/aws_iam_password_policy.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 # author: Viktor Yakovlyev
 class AwsIamPasswordPolicy < Inspec.resource(1)
   name 'aws_iam_password_policy'

--- a/libraries/aws_iam_role.rb
+++ b/libraries/aws_iam_role.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 class AwsIamRole < Inspec.resource(1)
   name 'aws_iam_role'
   desc 'Verifies settings for an IAM Role'

--- a/libraries/aws_iam_root_user.rb
+++ b/libraries/aws_iam_root_user.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 # author: Miles Tjandrawidjaja
 class AwsIamRootUser < Inspec.resource(1)
   name 'aws_iam_root_user'

--- a/libraries/aws_iam_user.rb
+++ b/libraries/aws_iam_user.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 # author: Alex Bedley
 # author: Steffanie Freeman
 # author: Simon Varlow

--- a/libraries/aws_iam_users.rb
+++ b/libraries/aws_iam_users.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 # author: Alex Bedley
 # author: Steffanie Freeman
 # author: Simon Varlow

--- a/libraries/aws_s3_bucket.rb
+++ b/libraries/aws_s3_bucket.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 # author: Matthew Dromazos
 class AwsS3Bucket < Inspec.resource(1)
   name 'aws_s3_bucket'

--- a/libraries/aws_sns_topic.rb
+++ b/libraries/aws_sns_topic.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 class AwsSnsTopic < Inspec.resource(1)
   name 'aws_sns_topic'
   desc 'Verifies settings for an SNS Topic'

--- a/libraries/aws_vpc.rb
+++ b/libraries/aws_vpc.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 class AwsVpc < Inspec.resource(1)
   name 'aws_vpc'
   desc 'Verifies settings for AWS VPC'

--- a/libraries/aws_vpcs.rb
+++ b/libraries/aws_vpcs.rb
@@ -1,3 +1,5 @@
+require '_aws'
+
 class AwsVpcs < Inspec.resource(1)
   name 'aws_vpcs'
   desc 'Verifies settings for AWS VPCs in bulk'


### PR DESCRIPTION
I simply added a `require _aws.rb` to all resources which needed it (which is all of them).  I don't know why resources shouldn't simply `require` the modules they need, rather than relying on a particular load order.

chef/inspec#2474
chef/inspec#2475
