### PR TITLE
Add have_access_logging_enabled matcher to aws_s3_bucket

### DIFF
--- a/docs/resources/aws_s3_bucket.md
+++ b/docs/resources/aws_s3_bucket.md
@@ -121,3 +121,9 @@ The `be_public` matcher tests if the bucket has potentially insecure access cont
 Note: This resource does not detect insecure object ACLs.
 
     it { should_not be_public }
+
+### have_access_logging_enabled
+
+The `have_access_logging_enabled` matcher tests if access logging is enabled for the s3 bucket.
+
+    it { should have_access_logging_enabled }

--- a/libraries/aws_s3_bucket.rb
+++ b/libraries/aws_s3_bucket.rb
@@ -35,6 +35,12 @@ class AwsS3Bucket < Inspec.resource(1)
       bucket_policy.any? { |s| s.effect == 'Allow' && s.principal == '*' }
   end
 
+  def has_access_logging_enabled?
+    return unless @exists
+    # This is simple enough to inline it.
+    !AwsS3Bucket::BackendFactory.create.get_bucket_logging(bucket: bucket_name).logging_enabled.nil?
+  end
+
   private
 
   def validate_params(raw_params)
@@ -96,6 +102,10 @@ class AwsS3Bucket < Inspec.resource(1)
 
       def get_bucket_policy(query)
         AWSConnection.new.s3_client.get_bucket_policy(query)
+      end
+
+      def get_bucket_logging(query)
+        AWSConnection.new.s3_client.get_bucket_logging(query)
       end
     end
   end

--- a/test/integration/default/build/s3.tf
+++ b/test/integration/default/build/s3.tf
@@ -42,6 +42,40 @@ output "s3_bucket_private_acl_public_policy_name" {
   value = "${aws_s3_bucket.private_acl_public_policy.id}"
 }
 
+
+resource "aws_s3_bucket" "log_bucket" {
+  bucket        = "inspec-testing-log-bucket-${terraform.env}.chef.io"
+  force_destroy = true
+  acl           = "log-delivery-write"
+}
+
+output "s3_bucket_log_bucket_name" {
+  value = "${aws_s3_bucket.log_bucket.id}"
+}
+
+resource "aws_s3_bucket" "acess_logging_enabled" {
+  bucket = "inspec-testing-acess-logging-enabled-${terraform.env}.chef.io"
+  acl    = "private"
+
+  logging {
+    target_bucket = "${aws_s3_bucket.log_bucket.id}"
+    target_prefix = "log/"
+  }
+}
+
+output "s3_bucket_access_logging_enabled_name" {
+  value = "${aws_s3_bucket.acess_logging_enabled.id}"
+}
+
+resource "aws_s3_bucket" "acess_logging_not_enabled" {
+  bucket = "inspec-testing-acess-logging-not-enabled-${terraform.env}.chef.io"
+  acl    = "private"
+}
+
+output "s3_bucket_access_logging_not_enabled_name" {
+  value = "${aws_s3_bucket.acess_logging_not_enabled.id}"
+}
+
 #=================================================================#
 #                       S3 Bucket Policies
 #=================================================================#

--- a/test/integration/default/verify/controls/aws_s3_bucket.rb
+++ b/test/integration/default/verify/controls/aws_s3_bucket.rb
@@ -5,6 +5,8 @@ fixtures = {}
   's3_bucket_auth_name',
   's3_bucket_private_acl_public_policy_name',  
   's3_bucket_public_region',
+  's3_bucket_access_logging_enabled_name',
+  's3_bucket_access_logging_not_enabled_name',
 ].each do |fixture_name|
   fixtures[fixture_name] = attribute(
     fixture_name,
@@ -109,5 +111,13 @@ control 'aws_s3_bucket matchers test' do
   end
   describe aws_s3_bucket(bucket_name: fixtures['s3_bucket_private_acl_public_policy_name']) do
     it { should be_public }
+  end
+
+  #-----------------  have_access_logging_enabled -----------------#  
+  describe aws_s3_bucket(bucket_name: fixtures['s3_bucket_access_logging_enabled_name']) do
+    it { should have_access_logging_enabled }
+  end
+  describe aws_s3_bucket(bucket_name: fixtures['s3_bucket_access_logging_not_enabled_name']) do
+    it { should_not have_access_logging_enabled }
   end
 end

--- a/test/unit/resources/aws_s3_bucket_test.rb
+++ b/test/unit/resources/aws_s3_bucket_test.rb
@@ -167,6 +167,14 @@ class AwsS3BucketPropertiesTest < Minitest::Test
   def test_be_public_public_acl
     assert(AwsS3Bucket.new('public').public?)
   end
+
+  def test_has_access_logging_enabled_positive
+    assert(AwsS3Bucket.new('public').has_access_logging_enabled?)
+  end
+
+  def test_has_access_logging_enabled_negative
+    refute(AwsS3Bucket.new('private').has_access_logging_enabled?)
+  end
   
 end
 
@@ -282,6 +290,17 @@ EOP
       }
       unless buckets.key?(query[:bucket])
         raise Aws::S3::Errors::NoSuchBucketPolicy.new(nil, nil)
+      end
+      buckets[query[:bucket]]
+    end
+
+    def get_bucket_logging(query)
+      buckets = {
+        'public' => OpenStruct.new({ logging_enabled: OpenStruct.new({ target_bucket: 'log-bucket' }) }),
+        'private' => OpenStruct.new({ logging_enabled: nil }),
+      }
+      unless buckets.key?(query[:bucket])
+        raise Aws::S3::Errors::NoSuchBucket.new(nil, nil)
       end
       buckets[query[:bucket]]
     end


### PR DESCRIPTION
Needed for CIS 2.6.

By enabling S3 bucket logging on target S3 buckets, it is possible to capture all events which may affect objects within an target buckets. Configuring logs to be placed in a separate bucket allows access to log information which can be useful in security and incident response workflows.

    describe aws_s3_bucket('test_bucket') do
         it { should have_access_logging_enabled }
    end

Fixes #205

Signed-off-by: Rony Xavier <rx294@nyu.edu>