### PR TITLE
Additional feilds for aws_iam_users

### DIFF
--- a/docs/resources/aws_iam_users.md
+++ b/docs/resources/aws_iam_users.md
@@ -48,6 +48,33 @@ The following examples show how to use this InSpec audit resource.
       it { should_not exist }
     end
 
+### Test that all users that have a console password should have used it at-least once
+
+    console_users_with_unused_password = aws_iam_users
+                                         .where(has_console_password?: true)
+                                         .where(password_never_used?: false)
+
+    describe console_users_with_unused_password do
+      it { should_not exist }
+    end
+
+### Test that atleast one user exists with console password and used it atleast once
+
+    console_users_with_used_password = aws_iam_users
+                                       .where(has_console_password?: true)
+                                       .where(password_ever_used?: false)
+
+    describe console_users_with_used_password do
+      it { should exist }
+    end
+
+
+### Test that users with used passwords longer that 90 days should not exists
+
+    describe aws_iam_users.where { password_last_used_days_ago > 90 } do
+      it { should_not exist }
+    end
+
 <br>
 
 ## Matchers

--- a/test/unit/resources/aws_iam_users_test.rb
+++ b/test/unit/resources/aws_iam_users_test.rb
@@ -60,6 +60,40 @@ class AwsIamUsersTestFilterCriteria < Minitest::Test
     assert_includes users.entries.map{ |u| u[:user_name] }, 'carol'
     refute_includes users.entries.map{ |u| u[:user_name] }, 'alice'
   end
+
+  #------------------------------------------#
+  #           password_ever_used?
+  #------------------------------------------#
+  def test_users_criteria_password_ever_used?
+    AwsIamUsers::Backend.select(Maiusb::Basic)
+    users = AwsIamUsers.new.where { password_ever_used? }
+    assert(2, users.entries.count)
+    assert_includes users.entries.map{ |u| u[:user_name] }, 'carol'
+    refute_includes users.entries.map{ |u| u[:user_name] }, 'alice'
+  end
+
+  #------------------------------------------#
+  #           password_never_used?
+  #------------------------------------------#
+  def test_users_criteria_password_never_used?
+    AwsIamUsers::Backend.select(Maiusb::Basic)
+    users = AwsIamUsers.new.where { password_never_used? }
+    assert(1, users.entries.count)
+    assert_includes users.entries.map{ |u| u[:user_name] }, 'alice'
+    refute_includes users.entries.map{ |u| u[:user_name] }, 'carol'
+  end
+
+  #------------------------------------------#
+  #        password_last_used_days_ago
+  #------------------------------------------#
+  def test_users_criteria_has_password_last_used_days_ago_10
+    AwsIamUsers::Backend.select(Maiusb::Basic)
+    users = AwsIamUsers.new.where(password_last_used_days_ago: 10)
+    puts users
+    assert(1, users.entries.count)
+    assert_includes users.entries.map{ |u| u[:user_name] }, 'bob'
+    refute_includes users.entries.map{ |u| u[:user_name] }, 'alice'
+  end
 end
 
 #=============================================================================#
@@ -107,12 +141,12 @@ module Maiusb
           OpenStruct.new({
             user_name: 'bob',
             create_date: DateTime.parse('2017-11-06T16:19:30Z'),
-            password_last_used: DateTime.parse('2017-11-06T19:19:30Z'),
+            password_last_used: Time.now - 10*24*60*60,
             }),
           OpenStruct.new({
             user_name: 'carol',
             create_date: DateTime.parse('2017-10-10T16:19:30Z'),
-            password_last_used: DateTime.parse('2017-10-28T19:19:30Z'),
+            password_last_used: Time.now - 91*24*60*60,
           }),
         ]
       })


### PR DESCRIPTION
CIS 1.3 we need to be able to search for unused passwords. Adding synthetic fields password_last_used_days_ago, password_ever_used, and password_never_used

Added Feilds:

password_last_used_days_ago
password_ever_used
password_never_used

Fixes #113

Signed-off-by: Rony Xavier <rx294@nyu.edu>