### PR TITLE
Ensure unique security group name while integration testing.

### DIFF
--- a/test/integration/default/build/ec2.tf
+++ b/test/integration/default/build/ec2.tf
@@ -189,7 +189,7 @@ output "vpc_non_default_instance_tenancy" {
 # Create a security group with a known description
 # in the default VPC
 resource "aws_security_group" "alpha" {
-  name        = "alpha"
+  name        = "${terraform.env}-alpha"
   description = "SG alpha"
   vpc_id      = "${data.aws_vpc.default.id}"
 }

--- a/test/integration/default/build/ec2.tf
+++ b/test/integration/default/build/ec2.tf
@@ -197,3 +197,7 @@ resource "aws_security_group" "alpha" {
 output "ec2_security_group_alpha_group_id" {
   value = "${aws_security_group.alpha.id}"
 }
+
+output "ec2_security_group_alpha_group_name" {
+  value = "${aws_security_group.alpha.name}"
+}

--- a/test/integration/default/verify/controls/aws_ec2_security_group.rb
+++ b/test/integration/default/verify/controls/aws_ec2_security_group.rb
@@ -3,6 +3,7 @@ fixtures = {}
   'ec2_security_group_default_vpc_id',
   'ec2_security_group_default_group_id',
   'ec2_security_group_alpha_group_id',
+  'ec2_security_group_alpha_group_name',
 ].each do |fixture_name|
   fixtures[fixture_name] = attribute(
     fixture_name,
@@ -33,7 +34,7 @@ control "aws_ec2_security_group properties" do
   end
 
   describe aws_ec2_security_group(fixtures['ec2_security_group_alpha_group_id']) do
-    its('group_name') { should cmp 'alpha' }
+    its('group_name') { should cmp fixtures['ec2_security_group_alpha_group_name'] }
     its('vpc_id') { should cmp  fixtures['ec2_security_group_default_vpc_id'] }
     its('description') { should cmp 'SG alpha' }
   end


### PR DESCRIPTION
Because the security group name was 'alpha', if we ran more than one instance of the test it could collide with the other instance. This patch resolves this issue.