### PR TITLE
Add support for using AWS credentials from an instance's role

### DIFF
--- a/libraries/_aws_connection.rb
+++ b/libraries/_aws_connection.rb
@@ -11,12 +11,14 @@ class AWSConnection
     creds = nil
     if ENV['AWS_PROFILE']
       creds = Aws::SharedCredentials.new(profile_name: ENV['AWS_PROFILE'])
-    else
+    elsif ENV['AWS_ACCESS_KEY_ID'] and ENV['AWS_SECRET_ACCESS_KEY']
       creds = Aws::Credentials.new(
         ENV['AWS_ACCESS_KEY_ID'],
         ENV['AWS_SECRET_ACCESS_KEY'],
         ENV['AWS_SESSION_TOKEN'],
       )
+    else
+      creds = Aws::InstanceProfileCredentials.new
     end
     opts = {
       region: ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'],


### PR DESCRIPTION
Use Aws::InstanceProfileCredentials to grab creds from role assumed by the instance.

Update:
```
  def initialize
    creds = nil
    if ENV['AWS_PROFILE']
      creds = Aws::SharedCredentials.new(profile_name: ENV['AWS_PROFILE'])
    elsif ENV['AWS_ACCESS_KEY_ID'] and ENV['AWS_SECRET_ACCESS_KEY']
      creds = Aws::Credentials.new(
        ENV['AWS_ACCESS_KEY_ID'],
        ENV['AWS_SECRET_ACCESS_KEY'],
        ENV['AWS_SESSION_TOKEN'],
      )
    else
      creds = Aws::InstanceProfileCredentials.new
    end
    opts = {
      region: ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'],
      credentials: creds,
    }
    Aws.config.update(opts)
  end
```
Fixes #68

Signed-off-by: Rony Xavier <rx294@nyu.edu>